### PR TITLE
chore: add golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   go: circleci/go@1.7.1
 
 jobs:
-  test:
+  Unit Tests:
     executor:
       name: go/default
       tag: '1.19'
@@ -17,8 +17,15 @@ jobs:
           covermode: atomic
           failfast: true
           race: true
+  Linting:
+    docker:
+      - image: golangci/golangci-lint:v1.50-alpine
+    steps:
+      - checkout
+      - run: golangci-lint run -v ./...
 
 workflows:
-  main:
+  CI:
     jobs:
-      - test
+      - Unit Tests
+      - Linting

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,115 @@
+run:
+  build-tags:
+    - integration
+  concurrency: 4
+  issues-exit-code: 1
+  skip-dirs: []
+  tests: true
+  timeout: 5m
+
+linters-settings:
+  errcheck:
+    check-blank: true
+    check-type-assertions: true
+  exhaustive:
+    default-signifies-exhaustive: true
+  goconst:
+    ignore-calls: false
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+  gocyclo:
+    min-complexity: 10
+  goimports:
+    local-prefixes: github.com/snyk/cli-extension-sbom
+  gosimple:
+    checks: ["all"]
+  govet:
+    check-shadowing: true
+    disable:
+      - fieldalignment
+  lll:
+    line-length: 160
+  misspell:
+    locale: US
+  nolintlint:
+    allow-unused: false
+    require-explanation: true
+    require-specific: true
+  prealloc:
+    simple: true
+    range-loops: true
+    for-loops: true
+  promlinter:
+    strict: true
+  staticcheck:
+    checks: ["all"]
+  stylecheck:
+    checks: ["all"]
+    http-status-code-whitelist: []
+  varcheck:
+    exported-fields: true
+
+linters:
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - dogsled
+    - dupl
+    - durationcheck
+    - errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forbidigo
+    - forcetypeassert
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - goimports
+    - goprintffuncname
+    - gosec
+    - interfacebloat
+    - ireturn
+    - lll
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - noctx
+    - nolintlint
+    - prealloc
+    - predeclared
+    - promlinter
+    - rowserrcheck
+    - sqlclosecheck
+    - stylecheck
+    - tagliatelle
+    - tenv
+    - testpackage
+    - thelper
+    - tparallel
+    - unconvert
+    - unparam
+    - usestdlibvars
+    - wastedassign
+    - whitespace
+    - wrapcheck
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - bodyclose
+        - goconst
+        - ireturn

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -13,119 +13,125 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const SBOMWorkflowScheme = "flw://sbom"
-const DepGraphWorkflowScheme = "flw://depgraph"
-// TODO: need to check with Peter S. if this URL scheme is correct
-const OutputWorkflowScheme = "did://sbom/cyclonedx"
+const (
+	baseURL                 = "https://api.snyk.io" // TODO: we should make this configurable.
+	apiVersion              = "2022-03-31~experimental"
+	mimeTypeCycloneDXJSON   = "application/vnd.cyclonedx+json"
+	sbomFormatCycloneDXJSON = "cyclonedx+json"
+)
 
-func SBOMWorkflow(ic workflow.InvocationContext, input []workflow.Data) ([]workflow.Data, error) {
-	var sbomList []workflow.Data
+var (
+	WorkflowID, _         = url.Parse("did://sbom/cyclonedx") // TODO: need to check with Peter S. if this URL scheme is correct.
+	DepGraphWorkflowID, _ = url.Parse("flw://depgraph")       // TODO: import from legacy cli workflows
+)
 
-	var workflowEngineInstance = ic.GetEngine()
+func SBOMWorkflow(
+	ictx workflow.InvocationContext,
+	input []workflow.Data,
+) (sbomList []workflow.Data, err error) {
+	var workflowEngineInstance = ictx.GetEngine()
 
-	DepGraphWorkflowID, err := url.Parse(DepGraphWorkflowScheme)
-	
+	// TODO: show a spinner before we do any work.
+	depGraphs, err := workflowEngineInstance.Invoke(DepGraphWorkflowID)
 	if err != nil {
-		// TODO: We need to propogate these errors to the core engine.
-		return sbomList, err
+		// TODO: We need to propagate these errors to the core engine.
+		return sbomList, fmt.Errorf("error while invoking DepGraph workflow: %w", err)
 	}
 
-	depGraphData, err := workflowEngineInstance.Invoke(DepGraphWorkflowID)
-
-	if err != nil {
-		// TODO: We need to propogate these errors to the core engine.
-		return sbomList, err
-	}
-
-	// iterate over depgraphs and generate sbom
-	for _, depGraph := range depGraphData {
-		identifier := depGraph.GetIdentifier()
-		if identifier.Host == "depgraph" {
-			depGraphPayload, ok := depGraph.GetPayload().([]byte)
-			if !ok {
-				// TODO: We need to propogate these errors to the core engine.
-				// Content of the error should be updated later to match the error state.
-				return sbomList, errors.New("invalid dependency graph for sbom conversion")
-			}
-
-			sbom, err := convertDepGraphToSBOM(context.Background(), ic, depGraphPayload, "cyclonedx+json")
-			if err != nil {
-				// TODO: We need to propogate these errors to the core engine.
-				return sbomList, err
-			}
-
-			workflowIdentifier, err := url.Parse(OutputWorkflowScheme)
-			if err != nil {
-				// TODO: We need to propogate these errors to the core engine.
-				return sbomList, err
-			}
-
-			// create output data
-			data := workflow.NewDataFromInput(depGraph, workflowIdentifier, "application/vnd.cyclonedx+json", sbom)
-			sbomList = append(sbomList, data)
+	for _, depGraph := range depGraphs {
+		// TODO: check with Peter S. if this condition is good enough.
+		if depGraph.GetIdentifier().Host != "depgraph" {
+			continue
 		}
+
+		depGraphPayload := depGraph.GetPayload()
+		depGraphBytes, ok := depGraphPayload.([]byte)
+		if !ok {
+			// TODO: We need to propagate these errors to the core engine.
+			return nil, fmt.Errorf("invalid dep graph type for SBOM conversion (want []byte, got %T)", depGraphPayload)
+		}
+
+		sbom, err := convertDepGraphToSBOM(
+			context.Background(),
+			ictx,
+			depGraphBytes,
+			sbomFormatCycloneDXJSON,
+		)
+		if err != nil {
+			// TODO: We need to propagate these errors to the core engine.
+			return nil, err
+		}
+
+		sbomList = append(sbomList, workflow.NewDataFromInput(
+			depGraph,
+			WorkflowID,
+			mimeTypeCycloneDXJSON,
+			sbom,
+		))
 	}
 
 	return sbomList, nil
 }
 
-func convertDepGraphToSBOM(ctx context.Context, ic workflow.InvocationContext, depGraph []byte, format string) (sbom []byte, err error) {
-	baseURL := "https://api.snyk.io"
-	apiVersion := "2022-03-31~experimental"
+func convertDepGraphToSBOM(
+	ctx context.Context, // TODO: should we rather get a context.Context from the invocation context?
+	ictx workflow.InvocationContext,
+	depGraph []byte,
+	format string,
+) (sbom []byte, err error) {
+	config := ictx.GetConfiguration()
 
-	workflowConfiguration := ic.GetConfiguration()
+	token := config.GetString("token")
+	orgID := config.GetString("org")
 
-	token := workflowConfiguration.GetString("token")
-	orgID := workflowConfiguration.GetString("org")
-
-	url := fmt.Sprintf(
-		"%s/hidden/orgs/%s/sbom?version=%s&format=%s",
-		baseURL, orgID, apiVersion, url.QueryEscape(format),
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		fmt.Sprintf(
+			"%s/hidden/orgs/%s/sbom?version=%s&format=%s",
+			baseURL, orgID, apiVersion, url.QueryEscape(format),
+		),
+		bytes.NewBuffer([]byte(fmt.Sprintf(`{"depGraph":%s}`, depGraph))),
 	)
-
-	body := bytes.NewBuffer([]byte(fmt.Sprintf(`{"depGraph":%s}`, depGraph)))
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("error while creating request: %w", err)
+	}
 	req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
 	req.Header.Set("Content-Type", "application/json")
-	if err != nil {
-		return nil, err
-	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error while making request: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("could not convert to SBOM (status: %s)", resp.Status)
 	}
 
-	if resp.Header.Get("Content-Type") != "application/vnd.cyclonedx+json" {
+	if resp.Header.Get("Content-Type") != mimeTypeCycloneDXJSON {
 		return nil, errors.New("received unexpected response format")
 	}
 
+	defer resp.Body.Close()
 	sbom, err = io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not read response body: %w", err)
 	}
 
 	return sbom, nil
 }
 
 func Init(e workflow.Engine) error {
-	WorkflowID, _ := url.Parse(OutputWorkflowScheme)
-
 	flagset := pflag.NewFlagSet("snyk-cli-extension-sbom", pflag.ExitOnError)
-	// TODO
+	// TODO: add proper user documentation.
 	flagset.String("file", "", "usage docs for file option")
-	// TODO
+	// TODO: add proper user documentation.
 	flagset.StringP("format", "f", "text", "usage docs for format option")
 
 	c := workflow.ConfigurationOptionsFromFlagset(flagset)
 
 	if _, err := e.Register(WorkflowID, c, SBOMWorkflow); err != nil {
-		return err
+		return fmt.Errorf("error while registering SBOM workflow: %w", err)
 	}
 
 	return nil

--- a/pkg/sbom/sbom_test.go
+++ b/pkg/sbom/sbom_test.go
@@ -1,12 +1,13 @@
-package sbom
+package sbom_test
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/cli-extension-sbom/pkg/sbom"
 )
 
 func TestInit(t *testing.T) {
@@ -16,11 +17,12 @@ func TestInit(t *testing.T) {
 	err := e.Init()
 	assert.NoError(t, err)
 
-	err = Init(e)
+	err = sbom.Init(e)
 	assert.NoError(t, err)
 
-	WorkflowID, _ := url.Parse(OutputWorkflowScheme)
+	// TODO: test the workflow invocation.
+	t.Skip()
 
-	_, err = e.Invoke(WorkflowID)
+	_, err = e.Invoke(sbom.WorkflowID)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
This adds 

* a golangci-lint configuration
* a lint job in CircleCI

Code has been refactored to appease the linter, with no logical changes except for returned errors being wrapped, since the lint rules called for this.

The linter configuration has been copied over from https://github.com/snyk/go-service-sample