### PR TITLE
refactor: move API call to service package

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,6 +33,10 @@ linters-settings:
     check-shadowing: true
     disable:
       - fieldalignment
+  ireturn:
+    allow:
+      - error
+      - github.com/snyk/go-application-framework/pkg/workflow.Data
   lll:
     line-length: 160
   misspell:

--- a/internal/mocks/service.go
+++ b/internal/mocks/service.go
@@ -5,8 +5,12 @@ import (
 	"net/http/httptest"
 )
 
-func NewMockSBOMService(response []byte) *httptest.Server {
+func NewMockSBOMService(response []byte, assertions ...func(r *http.Request)) *httptest.Server {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, assert := range assertions {
+			assert(r)
+		}
+
 		w.Header().Set("Content-Type", "application/vnd.cyclonedx+json")
 		if _, err := w.Write(response); err != nil {
 			panic(err)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/networking"
+)
+
+type SBOMFormat string
+
+const (
+	apiVersion            = "2022-03-31~experimental"
+	MimeTypeCycloneDXJSON = "application/vnd.cyclonedx+json"
+	MimeTypeJSON          = "application/json"
+
+	SBOMFormatCycloneDXJSON SBOMFormat = "cyclonedx+json"
+)
+
+func DepGraphToSBOM(
+	cfg configuration.Configuration,
+	depGraph []byte,
+	format SBOMFormat,
+) (docs []byte, err error) {
+	orgID := cfg.GetString(configuration.ORGANIZATION)
+	apiURL := cfg.GetString(configuration.API_URL)
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		buildURL(apiURL, orgID, format),
+		bytes.NewBuffer([]byte(fmt.Sprintf(`{"depGraph":%s}`, depGraph))),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error while creating request: %w", err)
+	}
+	req.Header.Add("Content-Type", MimeTypeJSON)
+
+	resp, err := networking.
+		NewNetworkAccess(cfg).
+		GetHttpClient().
+		Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error while making request: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("could not convert to SBOM (status: %s)", resp.Status)
+	}
+
+	if resp.Header.Get("Content-Type") != MimeTypeCycloneDXJSON {
+		return nil, errors.New("received unexpected response format")
+	}
+
+	defer resp.Body.Close()
+	docs, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("could not read response body: %w", err)
+	}
+
+	return docs, nil
+}
+
+func buildURL(apiURL, orgID string, format SBOMFormat) string {
+	return fmt.Sprintf(
+		"%s/hidden/orgs/%s/sbom?version=%s&format=%s",
+		apiURL, orgID, apiVersion, url.QueryEscape(string(format)),
+	)
+}

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -1,24 +1,12 @@
 package sbom
 
 import (
-	"bytes"
-	"context"
-	"errors"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 
-	"github.com/snyk/go-application-framework/pkg/configuration"
-	"github.com/snyk/go-application-framework/pkg/networking"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/spf13/pflag"
-)
 
-const (
-	apiVersion              = "2022-03-31~experimental"
-	mimeTypeCycloneDXJSON   = "application/vnd.cyclonedx+json"
-	sbomFormatCycloneDXJSON = "cyclonedx+json"
+	"github.com/snyk/cli-extension-sbom/internal/service"
 )
 
 var (
@@ -28,88 +16,34 @@ var (
 
 func SBOMWorkflow(
 	ictx workflow.InvocationContext,
-	input []workflow.Data,
-) (sbomList []workflow.Data, err error) {
+	_ []workflow.Data,
+) (sbomDocs []workflow.Data, err error) {
 	var workflowEngineInstance = ictx.GetEngine()
 
 	depGraphs, err := workflowEngineInstance.Invoke(DepGraphWorkflowID)
 	if err != nil {
-		return sbomList, err
+		return nil, err
 	}
 
 	for _, depGraph := range depGraphs {
-		depGraphPayload := depGraph.GetPayload()
-		depGraphBytes, ok := depGraphPayload.([]byte)
-		if !ok {
-			return nil, fmt.Errorf("invalid dep graph type for SBOM conversion (want []byte, got %T)", depGraphPayload)
+		depGraphBytes, err := getPayloadBytes(depGraph)
+		if err != nil {
+			return nil, err
 		}
 
-		sbom, err := convertDepGraphToSBOM(
-			ictx,
+		sbomBytes, err := service.DepGraphToSBOM(
+			ictx.GetConfiguration(),
 			depGraphBytes,
-			sbomFormatCycloneDXJSON,
+			service.SBOMFormatCycloneDXJSON,
 		)
 		if err != nil {
 			return nil, err
 		}
 
-		sbomList = append(sbomList, workflow.NewDataFromInput(
-			depGraph,
-			WorkflowID,
-			mimeTypeCycloneDXJSON,
-			sbom,
-		))
+		sbomDocs = append(sbomDocs, newData(service.MimeTypeCycloneDXJSON, sbomBytes))
 	}
 
-	return sbomList, nil
-}
-
-func convertDepGraphToSBOM(
-	ictx workflow.InvocationContext,
-	depGraph []byte,
-	format string,
-) (sbom []byte, err error) {
-	config := ictx.GetConfiguration()
-
-	orgID := config.GetString(configuration.ORGANIZATION)
-	apiURL := config.GetString(configuration.API_URL)
-
-	req, err := http.NewRequestWithContext(
-		context.Background(),
-		http.MethodPost,
-		fmt.Sprintf(
-			"%s/hidden/orgs/%s/sbom?version=%s&format=%s",
-			apiURL, orgID, apiVersion, url.QueryEscape(format),
-		),
-		bytes.NewBuffer([]byte(fmt.Sprintf(`{"depGraph":%s}`, depGraph))),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error while creating request: %w", err)
-	}
-	network := networking.NewNetworkAccess(config)
-	network.AddHeaderField("Content-Type", "application/json")
-	client := network.GetHttpClient()
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("error while making request: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("could not convert to SBOM (status: %s)", resp.Status)
-	}
-
-	if resp.Header.Get("Content-Type") != mimeTypeCycloneDXJSON {
-		return nil, errors.New("received unexpected response format")
-	}
-
-	defer resp.Body.Close()
-	sbom, err = io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("could not read response body: %w", err)
-	}
-
-	return sbom, nil
+	return sbomDocs, nil
 }
 
 func Init(e workflow.Engine) error {
@@ -126,4 +60,21 @@ func Init(e workflow.Engine) error {
 	}
 
 	return nil
+}
+
+func newData(contentType string, sbom []byte) workflow.Data {
+	return workflow.NewData(
+		WorkflowID,
+		contentType,
+		sbom,
+	)
+}
+
+func getPayloadBytes(data workflow.Data) ([]byte, error) {
+	payload := data.GetPayload()
+	bytes, ok := payload.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("invalid payload type (want []byte, got %T)", payload)
+	}
+	return bytes, nil
 }


### PR DESCRIPTION
This refactors the workflow function to extract the API call portion to a `service` package.