### PR TITLE
fix: set correct content type on SBOM results

### DIFF
--- a/internal/mocks/service.go
+++ b/internal/mocks/service.go
@@ -5,17 +5,29 @@ import (
 	"net/http/httptest"
 )
 
-func NewMockSBOMService(response []byte, assertions ...func(r *http.Request)) *httptest.Server {
+type response struct {
+	contentType string
+	body        []byte
+}
+
+func NewMockSBOMService(response response, assertions ...func(r *http.Request)) *httptest.Server {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for _, assert := range assertions {
 			assert(r)
 		}
 
-		w.Header().Set("Content-Type", "application/vnd.cyclonedx+json")
-		if _, err := w.Write(response); err != nil {
+		w.Header().Set("Content-Type", response.contentType)
+		if _, err := w.Write(response.body); err != nil {
 			panic(err)
 		}
 	}))
 
 	return ts
+}
+
+func NewMockResponse(c string, b []byte) response {
+	return response{
+		contentType: c,
+		body:        b,
+	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -10,10 +10,14 @@ import (
 	"net/url"
 )
 
+type SBOMResult struct {
+	Doc      []byte
+	MIMEType string
+}
+
 const (
-	apiVersion            = "2022-03-31~experimental"
-	MimeTypeCycloneDXJSON = "application/vnd.cyclonedx+json"
-	MimeTypeJSON          = "application/json"
+	apiVersion   = "2022-03-31~experimental"
+	MimeTypeJSON = "application/json"
 )
 
 func DepGraphToSBOM(
@@ -23,7 +27,7 @@ func DepGraphToSBOM(
 	depGraph []byte,
 	format string,
 	logger *log.Logger,
-) (docs []byte, err error) {
+) (result *SBOMResult, err error) {
 	req, err := http.NewRequestWithContext(
 		context.Background(),
 		http.MethodPost,
@@ -47,14 +51,14 @@ func DepGraphToSBOM(
 	}
 
 	defer resp.Body.Close()
-	docs, err = io.ReadAll(resp.Body)
+	doc, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("could not read response body: %w", err)
 	}
 
 	logger.Println("Successfully converted depGraph to SBOM")
 
-	return docs, nil
+	return &SBOMResult{Doc: doc, MIMEType: resp.Header.Get("Content-Type")}, nil
 }
 
 func buildURL(apiURL, orgID, format string) string {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -2,8 +2,10 @@ package service_test
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,24 +14,56 @@ import (
 	. "github.com/snyk/cli-extension-sbom/internal/service"
 )
 
-func TestDepGraphToSBOM(t *testing.T) {
-	response := []byte("{}")
-	mockSBOMService := mocks.NewMockSBOMService(response, func(r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, MimeTypeJSON, r.Header.Get("Content-Type"))
-		assert.Equal(t, "/hidden/orgs/c32727e4-2d6c-4780-aa1a-a89bcd16fe6f/sbom?version=2022-03-31~experimental&format=cyclonedx%2Bjson", r.RequestURI)
-	})
-	orgID := "c32727e4-2d6c-4780-aa1a-a89bcd16fe6f"
-	logger := log.New(&bytes.Buffer{}, "", 0)
+const orgID = "c32727e4-2d6c-4780-aa1a-a89bcd16fe6f"
 
-	doc, err := DepGraphToSBOM(
-		http.DefaultClient,
-		mockSBOMService.URL,
-		orgID,
-		[]byte("{}"),
-		"cyclonedx+json",
-		logger,
-	)
-	assert.NoError(t, err)
-	assert.Equal(t, response, doc)
+func TestDepGraphToSBOM(t *testing.T) {
+	tc := map[string]struct {
+		format              string
+		expectedContentType string
+		mockBody            []byte
+	}{
+		"CycloneDX 1.4 JSON": {
+			format:              "cyclonedx1.4+json",
+			expectedContentType: "application/vnd.cyclonedx+json",
+			mockBody:            []byte("{}"),
+		},
+		"CycloneDX 1.4 XML": {
+			format:              "cyclonedx1.4+xml",
+			expectedContentType: "application/vnd.cyclonedx+xml",
+			mockBody:            []byte("<?xml ?>"),
+		},
+		"SPDX 2.3 JSON": {
+			format:              "spdx2.3+json",
+			expectedContentType: "application/json",
+			mockBody:            []byte("{}"),
+		},
+	}
+
+	for name, tt := range tc {
+		t.Run(name, func(t *testing.T) {
+			response := mocks.NewMockResponse(tt.expectedContentType, tt.mockBody)
+			mockSBOMService := mocks.NewMockSBOMService(response, func(r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, MimeTypeJSON, r.Header.Get("Content-Type"))
+				assert.Equal(
+					t,
+					fmt.Sprintf("/hidden/orgs/c32727e4-2d6c-4780-aa1a-a89bcd16fe6f/sbom?version=2022-03-31~experimental&format=%s", url.QueryEscape(tt.format)),
+					r.RequestURI,
+				)
+			})
+			logger := log.New(&bytes.Buffer{}, "", 0)
+
+			res, err := DepGraphToSBOM(
+				http.DefaultClient,
+				mockSBOMService.URL,
+				orgID,
+				[]byte("{}"),
+				tt.format,
+				logger,
+			)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.mockBody, res.Doc)
+			assert.Equal(t, tt.expectedContentType, res.MIMEType)
+		})
+	}
 }

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -52,7 +52,7 @@ func SBOMWorkflow(
 			return nil, err
 		}
 
-		sbomBytes, err := service.DepGraphToSBOM(
+		result, err := service.DepGraphToSBOM(
 			ictx.GetNetworkAccess().GetHttpClient(),
 			config.GetString(configuration.API_URL),
 			config.GetString(configuration.ORGANIZATION),
@@ -64,7 +64,7 @@ func SBOMWorkflow(
 			return nil, err
 		}
 
-		sbomDocs = append(sbomDocs, newData(depGraph, service.MimeTypeCycloneDXJSON, sbomBytes))
+		sbomDocs = append(sbomDocs, newData(depGraph, result.MIMEType, result.Doc))
 	}
 
 	logger.Printf("Successfully generated %d document(s}\n", len(sbomDocs))
@@ -92,7 +92,7 @@ func Init(e workflow.Engine) error {
 func newData(depGraph workflow.Data, contentType string, sbom []byte) workflow.Data {
 	return workflow.NewDataFromInput(
 		depGraph,
-		workflow.NewTypeIdentifier(WorkflowID, "cyclonedx"),
+		workflow.NewTypeIdentifier(WorkflowID, "sbom"),
 		contentType,
 		sbom,
 	)

--- a/pkg/sbom/sbom_test.go
+++ b/pkg/sbom/sbom_test.go
@@ -42,7 +42,8 @@ func TestSBOMWorkflowSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mockSBOMService := svcmocks.NewMockSBOMService(expectedSBOM)
+	mockResponse := svcmocks.NewMockResponse("application/vnd.cyclonedx+json", expectedSBOM)
+	mockSBOMService := svcmocks.NewMockSBOMService(mockResponse)
 	defer mockSBOMService.Close()
 	mockICTX := mockInvocationContext(ctrl, mockSBOMService.URL)
 


### PR DESCRIPTION
This replaces all hardcoded instances of "cyclonedx" and changes to a dynamic approach, where the content type of a data payload is being determined by looking at the content type of the remote conversion.