### PR TITLE
feat: add POC for extended error interface

### DIFF
--- a/pkg/workflowerrors/catalog.go
+++ b/pkg/workflowerrors/catalog.go
@@ -1,0 +1,34 @@
+package workflowerrors
+
+import "errors"
+
+func NewExperimentalFlagError() WorkflowError {
+	return NewWorkflowError(
+		errors.New("experimental flag not set"),
+		"Please set the `--experimental` flag to enable running the `sbom` command.",
+	)
+}
+
+func NewEmptyOrgIDError() WorkflowError {
+	return NewWorkflowError(
+		errors.New("empty org ID"),
+		"Automatic detection of your org ID failed. Please supply an org ID by setting the `--org` flag.",
+	)
+}
+
+func NewFailedSCAError(err error) WorkflowError {
+	return NewWorkflowError(
+		err,
+		`We failed to detect a project or the dependencies for the detected project.
+		Please run with -d flag to debug or get in touch with customer support.`,
+	)
+}
+
+func NewFailedConversionError(err error) WorkflowError {
+	// TODO: check about authz/authn issues and give a different
+	// result depending on the error case.
+	return NewWorkflowError(
+		err,
+		`The conversion of the SCA result to an SBOM failed.`,
+	)
+}

--- a/pkg/workflowerrors/errors.go
+++ b/pkg/workflowerrors/errors.go
@@ -1,0 +1,27 @@
+package workflowerrors
+
+// WorkflowError is a CLI Extension specific error which gets
+// returned to the caller of a workflow. It distinguishes between
+// the internal technical error, and a customer facing error
+// message.
+type WorkflowError struct {
+	err error
+	msg string
+}
+
+// Error returns the user-facing error message.
+func (e WorkflowError) Error() string {
+	return e.msg
+}
+
+// GetError returns the internal error instance.
+func (e WorkflowError) GetError() error {
+	return e.err
+}
+
+func NewWorkflowError(e error, msg string) WorkflowError {
+	return WorkflowError{
+		err: e,
+		msg: msg,
+	}
+}


### PR DESCRIPTION
This is a first draft proposal on how we could return richer errors from the sbom workflow. The idea is to have a `WorkflowError` definition, which implements the `error` interface; but also holds a friendly user-facing message in its state. `WorkflowErrors` could be extended with more metadata, such as severity level or desired exit code.

This screenshot demonstrates the difference: while the actual error message is going to the logs, the user is being presented with a different message.

<img width="644" alt="Screenshot 2023-02-24 at 11 30 46" src="https://user-images.githubusercontent.com/1739114/221158470-5c3f3ab0-d064-4ad3-8f7a-7664904a4a7b.png">


```go
func NewExperimentalFlagError() WorkflowError {
	return NewWorkflowError(
		errors.New("experimental flag not set"), // internal error detail
		"Please set the `--experimental` flag to enable running the `sbom` command.", // user-facing message
	)
}
```