### PR TITLE
fix!: require a format from user

### DIFF
--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -37,6 +37,10 @@ func SBOMWorkflow(
 		return nil, fmt.Errorf("set `--experimental` flag to enable sbom command")
 	}
 
+	if format == "" {
+		return nil, fmt.Errorf("set `--format` to specify SBOM format. (cyclonedx1.4+json, cyclonedx1.4+xml, spdx2.3+json)")
+	}
+
 	logger.Println("Invoking depgraph workflow")
 
 	depGraphs, err := engine.Invoke(DepGraphWorkflowID)
@@ -78,7 +82,7 @@ func Init(e workflow.Engine) error {
 	flagset.Bool(flagExperimental, false, "Explicitly enable `sbom` command with the --experimental flag.")
 	flagset.Bool(flagUnmanaged, false, "For C/C++ only, scan all files for known open source dependencies and build an SBOM.")
 	flagset.String(flagFile, "", "Specify a package file.")
-	flagset.StringP(flagFormat, "f", "cyclonedx1.4+json", "Specify the SBOM output format. (cyclonedx1.4+json, cyclonedx1.4+xml, spdx2.3+json)")
+	flagset.StringP(flagFormat, "f", "", "Specify the SBOM output format. (cyclonedx1.4+json, cyclonedx1.4+xml, spdx2.3+json)")
 
 	c := workflow.ConfigurationOptionsFromFlagset(flagset)
 

--- a/pkg/sbom/sbom_test.go
+++ b/pkg/sbom/sbom_test.go
@@ -68,6 +68,8 @@ func mockInvocationContext(ctrl *gomock.Controller, sbomServiceURL string) workf
 			return "6277734c-fc84-4c74-9662-33d46ec66c53"
 		case configuration.API_URL:
 			return sbomServiceURL
+		case "format":
+			return "cyclonedx1.4+json"
 		default:
 			return ""
 		}


### PR DESCRIPTION
This removes the default fallback to CycloneDX JSON as an output format and instead makes setting the format argument mandatory.