### PR TITLE
fix: improved user-facing error messages

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -54,7 +54,9 @@ linters-settings:
   staticcheck:
     checks: ["all"]
   stylecheck:
-    checks: ["all"]
+    checks:
+      - all
+      - "-ST1003" # Allow underscores in package names
     http-status-code-whitelist: []
   varcheck:
     exported-fields: true

--- a/internal/extension_errors/errors.go
+++ b/internal/extension_errors/errors.go
@@ -1,0 +1,22 @@
+package extension_errors
+
+// SBOMExtensionError represents something gone wrong during the
+// execution of the CLI Extension. It holds error details, but
+// serializes to a human-friendly, customer facing message.
+// This is an interim solution until the integration of a generic
+// error-catalog interface.
+type SBOMExtensionError struct {
+	err     error
+	userMsg string
+}
+
+func New(err error, userMsg string) *SBOMExtensionError {
+	return &SBOMExtensionError{
+		err:     err,
+		userMsg: userMsg,
+	}
+}
+
+func (xerr SBOMExtensionError) Error() string {
+	return xerr.userMsg
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -67,3 +67,15 @@ func TestDepGraphToSBOM(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSBOMFormat_EmptyFormat(t *testing.T) {
+	err := ValidateSBOMFormat("")
+	assert.ErrorContains(t, err, "Must set `--format` flag to specify an SBOM format. "+
+		"Available formats are: cyclonedx1.4+json, cyclonedx1.4+xml, spdx2.3+json")
+}
+
+func TestValidateSBOMFormat_InvalidFormat(t *testing.T) {
+	err := ValidateSBOMFormat("not+a+format")
+	assert.ErrorContains(t, err, "The format provided (not+a+format) is not one of the available formats. "+
+		"Available formats are: cyclonedx1.4+json, cyclonedx1.4+xml, spdx2.3+json")
+}

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -7,6 +7,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/spf13/pflag"
 
+	"github.com/snyk/cli-extension-sbom/internal/extension_errors"
 	"github.com/snyk/cli-extension-sbom/internal/service"
 )
 
@@ -34,11 +35,11 @@ func SBOMWorkflow(
 	logger.Println("SBOM workflow start")
 
 	if !config.GetBool(flagExperimental) {
-		return nil, fmt.Errorf("set `--experimental` flag to enable sbom command")
+		return nil, extension_errors.New(nil, "Must set `--experimental` flag to enable sbom command.")
 	}
 
-	if format == "" {
-		return nil, fmt.Errorf("set `--format` to specify SBOM format. (cyclonedx1.4+json, cyclonedx1.4+xml, spdx2.3+json)")
+	if verr := service.ValidateSBOMFormat(format); verr != nil {
+		return nil, verr
 	}
 
 	logger.Println("Invoking depgraph workflow")


### PR DESCRIPTION
This introduces a new internal Error type, `SBOMExtensionError`, which serializes to a customer facing message. This is considered an interim solution until we integrate with the error-catalog, which is still actively being explored for CLI Extensions.

The covered error cases are:
* user does not set `--experimental` flag (this will be removed soon, anyway)
* user does not set `--format`
* user sets wrong format