### PR TITLE
fix: better error messages for unsuccessful API responses

### DIFF
--- a/internal/extension_errors/errors.go
+++ b/internal/extension_errors/errors.go
@@ -24,7 +24,15 @@ func (xerr SBOMExtensionError) Error() string {
 func NewInternalError(err error) *SBOMExtensionError {
 	return New(
 		err,
-		"An error occurred while running the underlying analysis which is required to generate an SBOM. "+
+		"An error occurred while running the underlying analysis which is required to generate the SBOM. "+
+			"Should this issue persist, please reach out to customer support.",
+	)
+}
+
+func NewRemoteError(err error) *SBOMExtensionError {
+	return New(
+		err,
+		"An error occurred while generating the SBOM. "+
 			"Should this issue persist, please reach out to customer support.",
 	)
 }

--- a/internal/mocks/service.go
+++ b/internal/mocks/service.go
@@ -8,6 +8,7 @@ import (
 type response struct {
 	contentType string
 	body        []byte
+	status      int
 }
 
 func NewMockSBOMService(response response, assertions ...func(r *http.Request)) *httptest.Server {
@@ -17,6 +18,9 @@ func NewMockSBOMService(response response, assertions ...func(r *http.Request)) 
 		}
 
 		w.Header().Set("Content-Type", response.contentType)
+		if response.status >= http.StatusContinue {
+			w.WriteHeader(response.status)
+		}
 		if _, err := w.Write(response.body); err != nil {
 			panic(err)
 		}
@@ -25,9 +29,10 @@ func NewMockSBOMService(response response, assertions ...func(r *http.Request)) 
 	return ts
 }
 
-func NewMockResponse(c string, b []byte) response {
+func NewMockResponse(c string, b []byte, status int) response {
 	return response{
 		contentType: c,
 		body:        b,
+		status:      status,
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -56,7 +56,7 @@ func DepGraphToSBOM(
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("could not convert to SBOM (status: %s)", resp.Status)
+		return nil, errorFromResponse(resp, orgID)
 	}
 
 	defer resp.Body.Close()
@@ -75,6 +75,36 @@ func buildURL(apiURL, orgID, format string) string {
 		"%s/hidden/orgs/%s/sbom?version=%s&format=%s",
 		apiURL, orgID, apiVersion, url.QueryEscape(format),
 	)
+}
+
+func errorFromResponse(resp *http.Response, orgID string) error {
+	err := fmt.Errorf("could not convert to SBOM (status: %s)", resp.Status)
+	switch resp.StatusCode {
+	case http.StatusBadRequest:
+		return extension_errors.New(
+			err,
+			"SBOM generation failed due to bad input arguments. "+
+				"Please make sure you are using the latest version of the Snyk CLI.",
+		)
+	case http.StatusUnauthorized:
+		return extension_errors.New(
+			err,
+			"Snyk failed to authenticate you based on on you API token. "+
+				"Please ensure that you have authenticated by running `snyk auth`.",
+		)
+	case http.StatusForbidden:
+		return extension_errors.New(
+			err,
+			fmt.Sprintf(
+				"Your account is not authorized to perform this action. "+
+					"Please ensure that you belong to the given organization and that "+
+					"the organization is entitled to use the Snyk API. (Org ID: %s)",
+				orgID,
+			),
+		)
+	default:
+		return extension_errors.NewRemoteError(err)
+	}
 }
 
 func ValidateSBOMFormat(candidate string) error {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -41,7 +41,7 @@ func TestDepGraphToSBOM(t *testing.T) {
 
 	for name, tt := range tc {
 		t.Run(name, func(t *testing.T) {
-			response := mocks.NewMockResponse(tt.expectedContentType, tt.mockBody)
+			response := mocks.NewMockResponse(tt.expectedContentType, tt.mockBody, http.StatusOK)
 			mockSBOMService := mocks.NewMockSBOMService(response, func(r *http.Request) {
 				assert.Equal(t, http.MethodPost, r.Method)
 				assert.Equal(t, MimeTypeJSON, r.Header.Get("Content-Type"))
@@ -80,8 +80,56 @@ func TestDepGraphToSBOM_FailedRequest(t *testing.T) {
 	)
 
 	assert.Nil(t, res)
-	assert.ErrorContains(t, err, "An error occurred while running the underlying analysis which is required to generate an SBOM. "+
+	assert.ErrorContains(t, err, "An error occurred while running the underlying analysis which is required to generate the SBOM. "+
 		"Should this issue persist, please reach out to customer support.")
+}
+
+func TestDepGraphToSBOM_UnsuccessfulResponse(t *testing.T) {
+	tc := map[string]struct {
+		statusCode  int
+		expectedErr string
+	}{
+		"Bad Request": {
+			statusCode: http.StatusBadRequest,
+			expectedErr: "SBOM generation failed due to bad input arguments. " +
+				"Please make sure you are using the latest version of the Snyk CLI.",
+		},
+		"Unauthorized": {
+			statusCode: http.StatusUnauthorized,
+			expectedErr: "Snyk failed to authenticate you based on on you API token. " +
+				"Please ensure that you have authenticated by running `snyk auth`.",
+		},
+		"Forbidden": {
+			statusCode: http.StatusForbidden,
+			expectedErr: "Your account is not authorized to perform this action. " +
+				"Please ensure that you belong to the given organization and that the organization is " +
+				"entitled to use the Snyk API. (Org ID: c32727e4-2d6c-4780-aa1a-a89bcd16fe6f)",
+		},
+		"Other Errors": {
+			statusCode: http.StatusInternalServerError,
+			expectedErr: "An error occurred while generating the SBOM. Should this issue persist, " +
+				"please reach out to customer support.",
+		},
+	}
+
+	for name, tt := range tc {
+		t.Run(name, func(t *testing.T) {
+			response := mocks.NewMockResponse("text/plain", []byte{}, tt.statusCode)
+			mockSBOMService := mocks.NewMockSBOMService(response)
+			logger := log.New(&bytes.Buffer{}, "", 0)
+
+			_, err := DepGraphToSBOM(
+				http.DefaultClient,
+				mockSBOMService.URL,
+				orgID,
+				[]byte("{}"),
+				"cyclonedx1.4+json",
+				logger,
+			)
+			assert.Error(t, err)
+			assert.ErrorContains(t, err, tt.expectedErr)
+		})
+	}
 }
 
 func TestValidateSBOMFormat_EmptyFormat(t *testing.T) {

--- a/pkg/sbom/sbom_test.go
+++ b/pkg/sbom/sbom_test.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"io"
 	"log"
+	"net/http"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -42,7 +43,7 @@ func TestSBOMWorkflow_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mockResponse := svcmocks.NewMockResponse("application/vnd.cyclonedx+json", expectedSBOM)
+	mockResponse := svcmocks.NewMockResponse("application/vnd.cyclonedx+json", expectedSBOM, http.StatusOK)
 	mockSBOMService := svcmocks.NewMockSBOMService(mockResponse)
 	defer mockSBOMService.Close()
 	mockICTX := mockInvocationContext(ctrl, mockSBOMService.URL)
@@ -126,7 +127,7 @@ func TestSBOMWorkflow_InvalidPayload(t *testing.T) {
 
 	_, err := sbom.SBOMWorkflow(mockICTX, nil)
 
-	assert.ErrorContains(t, err, "An error occurred while running the underlying analysis which is required to generate an SBOM. "+
+	assert.ErrorContains(t, err, "An error occurred while running the underlying analysis which is required to generate the SBOM. "+
 		"Should this issue persist, please reach out to customer support.")
 }
 


### PR DESCRIPTION
This adds user-friendly error messages for unsuccessful API responses, such as
* 400 Bad Request
* 401 Unauthorized
* 403 Forbidden
* other non-200 codes