### PR TITLE
fix: better error msg when reading of response body fails

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -62,7 +62,7 @@ func DepGraphToSBOM(
 	defer resp.Body.Close()
 	doc, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("could not read response body: %w", err)
+		return nil, extension_errors.NewInternalError(fmt.Errorf("could not read response body: %w", err))
 	}
 
 	logger.Println("Successfully converted depGraph to SBOM")


### PR DESCRIPTION
This returns a user-friendly, generic internal error message when the reading of the API response body fails (which is not expected to happen regularly)