### PR TITLE
fix: add --experimental, ignore

### DIFF
--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -17,9 +17,10 @@ var (
 )
 
 const (
-	flagUnmanaged = "unmanaged"
-	flagFile      = "file"
-	flagFormat    = "format"
+	flagExperimental = "experimental"
+	flagUnmanaged    = "unmanaged"
+	flagFile         = "file"
+	flagFormat       = "format"
 )
 
 func SBOMWorkflow(
@@ -84,6 +85,7 @@ func SBOMWorkflow(
 func Init(e workflow.Engine) error {
 	flagset := pflag.NewFlagSet("snyk-cli-extension-sbom", pflag.ExitOnError)
 
+	flagset.Bool(flagExperimental, false, "Deprecated. Will be ignored.")
 	flagset.Bool(flagUnmanaged, false, "For C/C++ only, scan all files for known open source dependencies and build an SBOM.")
 	flagset.String(flagFile, "", "Specify a package file.")
 	flagset.StringP(flagFormat, "f", "", "Specify the SBOM output format. (cyclonedx1.4+json, cyclonedx1.4+xml, spdx2.3+json)")


### PR DESCRIPTION
When a user sets an unsupported/unknown flag, `snyk sbom --help` will be executed.
To avoid this behaviour once we release the extension to GA and make the transition smoother, we re-introduce the experimental flag and just ignore it.

This partially reverts commit 4988deea27036758eee7b09dbea260bfbb275fb0.