### PR TITLE
chore: do not monitor project twice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: code test
           fail-on-issues: true
           severity-threshold: high
-          monitor-on-build: << parameters.monitor >>
+          monitor-on-build: false
 
 workflows:
   version: 2


### PR DESCRIPTION
* Disables monitoring step after code test, as it monitors dependencies anyways, what we do after testing dependencies step