### PR TITLE
feat: add additional flags with refactor and unit test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/golang/mock v1.6.0
-	github.com/snyk/go-application-framework v0.0.0-20230511121935-f02b01f91229
+	github.com/snyk/go-application-framework v0.0.0-20230524140501-c87830a0faf7
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0
 )
@@ -31,7 +31,7 @@ require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/zerolog v1.29.1 // indirect
-	github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650 // indirect
+	github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb // indirect
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -184,10 +184,10 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.29.1 h1:cO+d60CHkknCbvzEWxP0S9K6KqyTjrCNUy1LdQLCGPc=
 github.com/rs/zerolog v1.29.1/go.mod h1:Le6ESbR7hc+DP6Lt1THiV8CQSdkkNrd3R0XbEgp3ZBU=
-github.com/snyk/go-application-framework v0.0.0-20230511121935-f02b01f91229 h1:fUhHwvIGyACVPOFM/diVoZaA08B1fX7HvRoG+9P9K0g=
-github.com/snyk/go-application-framework v0.0.0-20230511121935-f02b01f91229/go.mod h1:QMdFROeuG06UULLD2hzN/P9RlKE6Ma6eskMwAqVOMkM=
-github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650 h1:CsLoEIHxq4i3d9di8RoN3J3D1/oK20oroEZUGShor0o=
-github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
+github.com/snyk/go-application-framework v0.0.0-20230524140501-c87830a0faf7 h1:tsozrFzzSUhcrqFKLnbIBTIPABlqOjf2xVhxLWkwjqs=
+github.com/snyk/go-application-framework v0.0.0-20230524140501-c87830a0faf7/go.mod h1:Aun65T/AmzxjZe9jZZBqia6RHwoS7oq8QB2UfQIcPjU=
+github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb h1:UwbUBfe1u5MYLhtCNOsFEM98tfEUWqgmaXam/UxU88Q=
+github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=
 github.com/spf13/afero v1.9.2/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -1,0 +1,34 @@
+package flags
+
+import "github.com/spf13/pflag"
+
+const (
+	FlagExperimental                 = "experimental"
+	FlagUnmanaged                    = "unmanaged"
+	FlagFile                         = "file"
+	FlagFormat                       = "format"
+	FlagAllProjects                  = "all-projects"
+	FlagDetectionDepth               = "detection-depth"
+	FlagPruneRepeatedSubDependencies = "prune-repeated-subdependencies"
+	FlagExclude                      = "exclude"
+	FlagName                         = "name"
+	FlagVersion                      = "version"
+)
+
+func GetFlagSet() *pflag.FlagSet {
+	flagSet := pflag.NewFlagSet("snyk-cli-extension-sbom", pflag.ExitOnError)
+
+	flagSet.Bool(FlagExperimental, false, "Deprecated. Will be ignored.")
+	flagSet.Bool(FlagUnmanaged, false, "For C/C++ only, scan all files for known open source dependencies and build an SBOM.")
+	flagSet.Bool(FlagAllProjects, false, "Auto-detect all projects in the working directory (including Yarn workspaces).")
+	flagSet.String(FlagExclude, "", "Can be used with --all-projects to indicate directory names and file names to exclude. Must be comma separated.")
+	flagSet.String(FlagDetectionDepth, "", "Use with --all-projects to indicate how many subdirectories to search. "+
+		"DEPTH must be a number, 1 or greater; zero (0) is the current directory.")
+	flagSet.BoolP(FlagPruneRepeatedSubDependencies, "p", false, "Prune dependency trees, removing duplicate sub-dependencies.")
+	flagSet.String(FlagFile, "", "Specify a package file.")
+	flagSet.String(FlagName, "", "Specify a name for the collection of all projects in the working directory.")
+	flagSet.String(FlagVersion, "", "Specify a version for the collection of all projects in the working directory.")
+	flagSet.StringP(FlagFormat, "f", "", "Specify the SBOM output format. (cyclonedx1.4+json, cyclonedx1.4+xml, spdx2.3+json)")
+
+	return flagSet
+}

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -1,0 +1,86 @@
+package flags_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/snyk/cli-extension-sbom/internal/flags"
+)
+
+func TestGetFlagSet(t *testing.T) {
+	flagSet := GetFlagSet()
+
+	tc := []struct {
+		flagName string
+		isBool   bool
+		expected interface{}
+	}{
+		{
+			flagName: FlagExperimental,
+			isBool:   true,
+			expected: false,
+		},
+		{
+			flagName: FlagUnmanaged,
+			isBool:   true,
+			expected: false,
+		},
+		{
+			flagName: FlagAllProjects,
+			isBool:   true,
+			expected: false,
+		},
+		{
+			flagName: FlagExclude,
+			isBool:   false,
+			expected: "",
+		},
+		{
+			flagName: FlagDetectionDepth,
+			isBool:   false,
+			expected: "",
+		},
+		{
+			flagName: FlagPruneRepeatedSubDependencies,
+			isBool:   true,
+			expected: false,
+		},
+		{
+			flagName: FlagFile,
+			isBool:   false,
+			expected: "",
+		},
+		{
+			flagName: FlagName,
+			isBool:   false,
+			expected: "",
+		},
+		{
+			flagName: FlagVersion,
+			isBool:   false,
+			expected: "",
+		},
+		{
+			flagName: FlagFormat,
+			isBool:   false,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.flagName, func(t *testing.T) {
+			var val interface{}
+			var err error
+
+			if tt.isBool {
+				val, err = flagSet.GetBool(tt.flagName)
+			} else {
+				val, err = flagSet.GetString(tt.flagName)
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, val)
+		})
+	}
+}

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -7,26 +7,15 @@ import (
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
-	"github.com/spf13/pflag"
 
 	"github.com/snyk/cli-extension-sbom/internal/errors"
+	"github.com/snyk/cli-extension-sbom/internal/flags"
 	"github.com/snyk/cli-extension-sbom/internal/service"
 )
 
 var (
 	WorkflowID         = workflow.NewWorkflowIdentifier("sbom")
 	DepGraphWorkflowID = workflow.NewWorkflowIdentifier("depgraph")
-)
-
-const (
-	flagExperimental = "experimental"
-	flagUnmanaged    = "unmanaged"
-	flagFile         = "file"
-	flagFormat       = "format"
-	flagAllProjects  = "all-projects"
-	flagExclude      = "exclude"
-	flagName         = "name"
-	flagVersion      = "version"
 )
 
 func SBOMWorkflow(
@@ -36,9 +25,9 @@ func SBOMWorkflow(
 	engine := ictx.GetEngine()
 	config := ictx.GetConfiguration()
 	logger := ictx.GetLogger()
-	format := config.GetString(flagFormat)
-	name := config.GetString(flagName)
-	version := config.GetString(flagVersion)
+	format := config.GetString(flags.FlagFormat)
+	name := config.GetString(flags.FlagName)
+	version := config.GetString(flags.FlagVersion)
 	errFactory := errors.NewErrorFactory(logger)
 
 	logger.Println("SBOM workflow start")
@@ -105,16 +94,7 @@ func SBOMWorkflow(
 }
 
 func Init(e workflow.Engine) error {
-	flagset := pflag.NewFlagSet("snyk-cli-extension-sbom", pflag.ExitOnError)
-
-	flagset.Bool(flagExperimental, false, "Deprecated. Will be ignored.")
-	flagset.Bool(flagUnmanaged, false, "For C/C++ only, scan all files for known open source dependencies and build an SBOM.")
-	flagset.Bool(flagAllProjects, false, "Auto-detect all projects in the working directory (including Yarn workspaces).")
-	flagset.String(flagExclude, "", "Can be used with --all-projects to indicate directory names and file names to exclude. Must be comma separated.")
-	flagset.String(flagFile, "", "Specify a package file.")
-	flagset.String(flagName, "", "Specify a name for the collection of all projects in the working directory.")
-	flagset.String(flagVersion, "", "Specify a version for the collection of all projects in the working directory.")
-	flagset.StringP(flagFormat, "f", "", "Specify the SBOM output format. (cyclonedx1.4+json, cyclonedx1.4+xml, spdx2.3+json)")
+	flagset := flags.GetFlagSet()
 
 	c := workflow.ConfigurationOptionsFromFlagset(flagset)
 


### PR DESCRIPTION
This PR adds support for the `--prune-repeated-subdependencies` flag and `--detection-depth` flag.

We also refactored flags into its own package and added a unit test.