### PR TITLE
fix: use filepath pkg to get directory name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/golang/mock v1.6.0
-	github.com/snyk/go-application-framework v0.0.0-20230524140501-c87830a0faf7
+	github.com/snyk/go-application-framework v0.0.0-20230526065140-1fabe799e3f9
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.29.1 h1:cO+d60CHkknCbvzEWxP0S9K6KqyTjrCNUy1LdQLCGPc=
 github.com/rs/zerolog v1.29.1/go.mod h1:Le6ESbR7hc+DP6Lt1THiV8CQSdkkNrd3R0XbEgp3ZBU=
-github.com/snyk/go-application-framework v0.0.0-20230524140501-c87830a0faf7 h1:tsozrFzzSUhcrqFKLnbIBTIPABlqOjf2xVhxLWkwjqs=
-github.com/snyk/go-application-framework v0.0.0-20230524140501-c87830a0faf7/go.mod h1:Aun65T/AmzxjZe9jZZBqia6RHwoS7oq8QB2UfQIcPjU=
+github.com/snyk/go-application-framework v0.0.0-20230526065140-1fabe799e3f9 h1:FS0NA9lcbrW4Oha217+DppFXlECeWcHa8RBIKIK3+Qs=
+github.com/snyk/go-application-framework v0.0.0-20230526065140-1fabe799e3f9/go.mod h1:Aun65T/AmzxjZe9jZZBqia6RHwoS7oq8QB2UfQIcPjU=
 github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb h1:UwbUBfe1u5MYLhtCNOsFEM98tfEUWqgmaXam/UxU88Q=
 github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -3,7 +3,7 @@ package sbom
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
@@ -67,7 +67,7 @@ func SBOMWorkflow(
 			if err != nil {
 				return nil, errFactory.NewDepGraphWorkflowError(err)
 			}
-			name = path.Base(wd)
+			name = filepath.Base(wd)
 		}
 		logger.Printf("Document subject: { Name: %q, Version: %q }\n", name, version)
 	}


### PR DESCRIPTION
This fixes and issue with getting the current directory name. It was wrongly using the `path` package, which is not aware of Windows path separators, but rather only treats `/` as a separator. This has been fix by replacing it with the `path/filepath` package.