### PR TITLE
[LINK-405] fix: fail SCA when generating for all projects

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,7 +24,7 @@ linters-settings:
       - performance
       - style
   gocyclo:
-    min-complexity: 10
+    min-complexity: 15
   goimports:
     local-prefixes: github.com/snyk/cli-extension-sbom
   gosimple:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/golang/mock v1.6.0
-	github.com/snyk/go-application-framework v0.0.0-20230526065140-1fabe799e3f9
+	github.com/snyk/go-application-framework v0.0.0-20230602151048-31fbf2587cab
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.29.1 h1:cO+d60CHkknCbvzEWxP0S9K6KqyTjrCNUy1LdQLCGPc=
 github.com/rs/zerolog v1.29.1/go.mod h1:Le6ESbR7hc+DP6Lt1THiV8CQSdkkNrd3R0XbEgp3ZBU=
-github.com/snyk/go-application-framework v0.0.0-20230526065140-1fabe799e3f9 h1:FS0NA9lcbrW4Oha217+DppFXlECeWcHa8RBIKIK3+Qs=
-github.com/snyk/go-application-framework v0.0.0-20230526065140-1fabe799e3f9/go.mod h1:Aun65T/AmzxjZe9jZZBqia6RHwoS7oq8QB2UfQIcPjU=
+github.com/snyk/go-application-framework v0.0.0-20230602151048-31fbf2587cab h1:sDzcsRD7v5hihBxG28ASOD87k0bORefUhGMWThUolSE=
+github.com/snyk/go-application-framework v0.0.0-20230602151048-31fbf2587cab/go.mod h1:Aun65T/AmzxjZe9jZZBqia6RHwoS7oq8QB2UfQIcPjU=
 github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb h1:UwbUBfe1u5MYLhtCNOsFEM98tfEUWqgmaXam/UxU88Q=
 github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -45,7 +45,11 @@ func SBOMWorkflow(
 
 	logger.Println("Invoking depgraph workflow")
 
-	depGraphs, err := engine.Invoke(DepGraphWorkflowID)
+	depGraphConfig := config.Clone()
+	if config.GetBool(flags.FlagAllProjects) {
+		depGraphConfig.Set("fail-fast", true)
+	}
+	depGraphs, err := engine.InvokeWithConfig(DepGraphWorkflowID, depGraphConfig)
 	if err != nil {
 		return nil, errFactory.NewDepGraphWorkflowError(err)
 	}

--- a/pkg/sbom/sbom_test.go
+++ b/pkg/sbom/sbom_test.go
@@ -211,7 +211,7 @@ func newMockEngine(ctrl *gomock.Controller, result []workflow.Data, err error) *
 
 	mockEngine.
 		EXPECT().
-		Invoke(gomock.Eq(sbom.DepGraphWorkflowID)).
+		InvokeWithConfig(gomock.Eq(sbom.DepGraphWorkflowID), gomock.Any()).
 		Return(result, err).
 		AnyTimes()
 


### PR DESCRIPTION
This sets the `fail-fast` option of the DepGraphWorkflow when invoking with `all-projects`. This is to avoid incomplete SCA results if some manifest files cannot be analysed (in which case `snyk test` will silently skip over them).