### PR TITLE
feat: single depGraph with subject

### DIFF
--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -1,6 +1,7 @@
 package sbom
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -56,7 +57,7 @@ func SBOMWorkflow(
 
 	numGraphs := len(depGraphs)
 	logger.Printf("Generating documents for %d depgraph(s)\n", numGraphs)
-	depGraphsBytes := make([][]byte, numGraphs)
+	depGraphsBytes := make([]json.RawMessage, numGraphs)
 	for i, depGraph := range depGraphs {
 		depGraphBytes, err := getPayloadBytes(depGraph) //nolint:govet // error is checked
 		if err != nil {


### PR DESCRIPTION
This commit adds functionality to the sbom service, allowing users to pass in a single depGraph *and* a subject that will be honored.

To achieve this, we simply send the multi-depgraph body with only one depGraph, and the subject with it.

Additionally, I've switched from using raw strings to construct the body-JSON to using `json.RawMessage` and proper types / structs. This also means that I've had to make the `Name` and `Version` fields of the `subject` type public. And to make the subject's usage easier in external packages, I've made the `Subject` type itself public as well.

`json.RawMessage` is nice because it can be used to tell Go that a certain field is already raw JSON, and has never been fully decoded into a custom type. As such, when marshaling JSON, that `RawMessage` is simply added to the rest of the document without any changes.