### PR TITLE
feat: maven args support [LINK-692]

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -14,6 +14,9 @@ const (
 	FlagName                         = "name"
 	FlagVersion                      = "version"
 	FlagDev                          = "dev"
+	FlagMavenAggregateProject        = "maven-aggregate-project"
+	FlagScanUnmanaged                = "scan-unmanaged"
+	FlagScanAllUnmanaged             = "scan-all-unmanaged"
 )
 
 func GetFlagSet() *pflag.FlagSet {
@@ -31,6 +34,9 @@ func GetFlagSet() *pflag.FlagSet {
 	flagSet.String(FlagVersion, "", "Specify a version for the collection of all projects in the working directory.")
 	flagSet.StringP(FlagFormat, "f", "", "Specify the SBOM output format. (cyclonedx1.4+json, cyclonedx1.4+xml, spdx2.3+json)")
 	flagSet.Bool(FlagDev, false, "Include development-only dependencies. Applicable only for some package managers.")
+	flagSet.Bool(FlagMavenAggregateProject, false, "Ensure all modules are resolvable by the Maven reactor.")
+	flagSet.Bool(FlagScanUnmanaged, false, "Specify an individual JAR, WAR, or AAR file.")
+	flagSet.Bool(FlagScanAllUnmanaged, false, "Auto-detect Maven, JAR, WAR, and AAR files recursively from the current folder.")
 
 	return flagSet
 }


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add support for [the maven specific args](https://docs.snyk.io/snyk-cli/commands/test#options-for-maven-projects) to this cli extension in order to make them available on the `snyk sbom` command.
