### PR TITLE
feat: gradle args support

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -17,6 +17,12 @@ const (
 	FlagMavenAggregateProject        = "maven-aggregate-project"
 	FlagScanUnmanaged                = "scan-unmanaged"
 	FlagScanAllUnmanaged             = "scan-all-unmanaged"
+	FlagSubProject                   = "sub-project"
+	FlagGradleSubProject             = "gradle-sub-project"
+	FlagAllSubProjects               = "all-sub-projects"
+	FlagConfigurationMatching        = "configuration-matching"
+	FlagConfigurationAttributes      = "configuration-attributes"
+	FlagInitScript                   = "init-script"
 )
 
 func GetFlagSet() *pflag.FlagSet {
@@ -37,6 +43,12 @@ func GetFlagSet() *pflag.FlagSet {
 	flagSet.Bool(FlagMavenAggregateProject, false, "Ensure all modules are resolvable by the Maven reactor.")
 	flagSet.Bool(FlagScanUnmanaged, false, "Specify an individual JAR, WAR, or AAR file.")
 	flagSet.Bool(FlagScanAllUnmanaged, false, "Auto-detect Maven, JAR, WAR, and AAR files recursively from the current folder.")
+	flagSet.String(FlagSubProject, "", "Name of Gradle sub-project to test.")
+	flagSet.String(FlagGradleSubProject, "", "Name of Gradle sub-project to test.")
+	flagSet.Bool(FlagAllSubProjects, false, "Test all sub-projects in a multi-project build.")
+	flagSet.String(FlagConfigurationMatching, "", "Resolve dependencies using only configuration(s) that match the specified Java regular expression.")
+	flagSet.String(FlagConfigurationAttributes, "", "Select certain values of configuration attributes to install and resolve dependencies.")
+	flagSet.String(FlagInitScript, "", "Use for projects that contain a Gradle initialization script.")
 
 	return flagSet
 }


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add support for [the gradle specific args](https://docs.snyk.io/snyk-cli/commands/test#options-for-gradle-projects) to this cli extension in order to make them available on the `snyk sbom` command.
