### PR TITLE
feat: add yarn, python flags

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -24,6 +24,7 @@ const (
 	FlagConfigurationAttributes      = "configuration-attributes"
 	FlagInitScript                   = "init-script"
 	FlagYarnWorkspaces               = "yarn-workspaces"
+	FlagPythonCommand                = "command"
 )
 
 func GetFlagSet() *pflag.FlagSet {
@@ -51,6 +52,7 @@ func GetFlagSet() *pflag.FlagSet {
 	flagSet.String(FlagConfigurationMatching, "", "Resolve dependencies using only configuration(s) that match the specified Java regular expression.")
 	flagSet.String(FlagConfigurationAttributes, "", "Select certain values of configuration attributes to install and resolve dependencies.")
 	flagSet.String(FlagInitScript, "", "Use for projects that contain a Gradle initialization script.")
+	flagSet.String(FlagPythonCommand, "", "Indicate which specific Python commands to use based on the Python version.")
 
 	return flagSet
 }

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -23,6 +23,7 @@ const (
 	FlagConfigurationMatching        = "configuration-matching"
 	FlagConfigurationAttributes      = "configuration-attributes"
 	FlagInitScript                   = "init-script"
+	FlagYarnWorkspaces               = "yarn-workspaces"
 )
 
 func GetFlagSet() *pflag.FlagSet {
@@ -31,6 +32,7 @@ func GetFlagSet() *pflag.FlagSet {
 	flagSet.Bool(FlagExperimental, false, "Deprecated. Will be ignored.")
 	flagSet.Bool(FlagUnmanaged, false, "For C/C++ only, scan all files for known open source dependencies and build an SBOM.")
 	flagSet.Bool(FlagAllProjects, false, "Auto-detect all projects in the working directory (including Yarn workspaces).")
+	flagSet.Bool(FlagYarnWorkspaces, false, "Detect and scan Yarn Workspaces only when a lockfile is in the root.")
 	flagSet.String(FlagExclude, "", "Can be used with --all-projects to indicate directory names and file names to exclude. Must be comma separated.")
 	flagSet.String(FlagDetectionDepth, "", "Use with --all-projects to indicate how many subdirectories to search. "+
 		"DEPTH must be a number, 1 or greater; zero (0) is the current directory.")

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -26,6 +26,7 @@ const (
 	FlagYarnWorkspaces               = "yarn-workspaces"
 	FlagPythonCommand                = "command"
 	FlagPythonSkipUnresolved         = "skip-unresolved"
+	FlagPythonPackageManager         = "package-manager"
 )
 
 func GetFlagSet() *pflag.FlagSet {
@@ -55,6 +56,7 @@ func GetFlagSet() *pflag.FlagSet {
 	flagSet.String(FlagInitScript, "", "Use for projects that contain a Gradle initialization script.")
 	flagSet.String(FlagPythonCommand, "", "Indicate which specific Python commands to use based on the Python version.")
 	flagSet.Bool(FlagPythonSkipUnresolved, false, "Skip Python packages that cannot be found in the environment.")
+	flagSet.String(FlagPythonPackageManager, "", `Add --package-manager=pip to your command if the file name is not "requirements.txt".`)
 
 	return flagSet
 }

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -25,6 +25,7 @@ const (
 	FlagInitScript                   = "init-script"
 	FlagYarnWorkspaces               = "yarn-workspaces"
 	FlagPythonCommand                = "command"
+	FlagPythonSkipUnresolved         = "skip-unresolved"
 )
 
 func GetFlagSet() *pflag.FlagSet {
@@ -53,6 +54,7 @@ func GetFlagSet() *pflag.FlagSet {
 	flagSet.String(FlagConfigurationAttributes, "", "Select certain values of configuration attributes to install and resolve dependencies.")
 	flagSet.String(FlagInitScript, "", "Use for projects that contain a Gradle initialization script.")
 	flagSet.String(FlagPythonCommand, "", "Indicate which specific Python commands to use based on the Python version.")
+	flagSet.Bool(FlagPythonSkipUnresolved, false, "Skip Python packages that cannot be found in the environment.")
 
 	return flagSet
 }

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -66,6 +66,11 @@ func TestGetFlagSet(t *testing.T) {
 			isBool:   false,
 			expected: "",
 		},
+		{
+			flagName: FlagYarnWorkspaces,
+			isBool:   true,
+			expected: false,
+		},
 	}
 
 	for _, tt := range tc {

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -81,6 +81,11 @@ func TestGetFlagSet(t *testing.T) {
 			isBool:   true,
 			expected: false,
 		},
+		{
+			flagName: FlagPythonPackageManager,
+			isBool:   false,
+			expected: "",
+		},
 	}
 
 	for _, tt := range tc {

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -76,6 +76,11 @@ func TestGetFlagSet(t *testing.T) {
 			isBool:   false,
 			expected: "",
 		},
+		{
+			flagName: FlagPythonSkipUnresolved,
+			isBool:   true,
+			expected: false,
+		},
 	}
 
 	for _, tt := range tc {

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -71,6 +71,11 @@ func TestGetFlagSet(t *testing.T) {
 			isBool:   true,
 			expected: false,
 		},
+		{
+			flagName: FlagPythonCommand,
+			isBool:   false,
+			expected: "",
+		},
 	}
 
 	for _, tt := range tc {


### PR DESCRIPTION


This adds additional config flags for ecosystems yarn and python:

*    `--yarn-workspaces`
*    `--command`
*    `--skip-unresolved`
*    `--package-manager`

See `snyk test --help` for details.
