### PR TITLE
fix: nuget assets-project-name

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -56,7 +56,7 @@ func GetFlagSet() *pflag.FlagSet {
 	flagSet.String(FlagGradleSubProject, "", "Name of Gradle sub-project to test.")
 	flagSet.Bool(FlagAllSubProjects, false, "Test all sub-projects in a multi-project build.")
 	flagSet.Bool(FlagNPMStrictOutOfSync, true, "Prevent testing out-of-sync lockfiles.")
-	flagSet.String(FlagNugetAssetsProjectName, "",
+	flagSet.Bool(FlagNugetAssetsProjectName, false,
 		"When you are monitoring a .NET project using NuGet PackageReference uses the project name in project.assets.json if found.")
 	flagSet.String(FlagNugetPkgsFolder, "", "Specify a custom path to the packages folder when using NuGet.")
 	flagSet.String(FlagConfigurationMatching, "", "Resolve dependencies using only configuration(s) that match the specified Java regular expression.")

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -93,8 +93,8 @@ func TestGetFlagSet(t *testing.T) {
 		},
 		{
 			flagName: FlagNugetAssetsProjectName,
-			isBool:   false,
-			expected: "",
+			isBool:   true,
+			expected: false,
 		},
 		{
 			flagName: FlagNugetPkgsFolder,


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

A tiny type fix for the `assets-project-name` argument for NuGet.