### PR TITLE
feat: add new formats for CycloneDX 1.5

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -34,6 +34,8 @@ const (
 var sbomFormats = [...]string{
 	"cyclonedx1.4+json",
 	"cyclonedx1.4+xml",
+	"cyclonedx1.5+json",
+	"cyclonedx1.5+xml",
 	"spdx2.3+json",
 }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -220,7 +220,7 @@ func TestValidateSBOMFormat_EmptyFormat(t *testing.T) {
 	errFactory := errors.NewErrorFactory(logger)
 	err := ValidateSBOMFormat(errFactory, "")
 	assert.ErrorContains(t, err, "Must set `--format` flag to specify an SBOM format. "+
-		"Available formats are: cyclonedx1.4+json, cyclonedx1.4+xml, spdx2.3+json")
+		"Available formats are: cyclonedx1.4+json, cyclonedx1.4+xml, cyclonedx1.5+json, cyclonedx1.5+xml, spdx2.3+json")
 }
 
 func TestValidateSBOMFormat_InvalidFormat(t *testing.T) {
@@ -228,5 +228,25 @@ func TestValidateSBOMFormat_InvalidFormat(t *testing.T) {
 	errFactory := errors.NewErrorFactory(logger)
 	err := ValidateSBOMFormat(errFactory, "not+a+format")
 	assert.ErrorContains(t, err, "The format provided (not+a+format) is not one of the available formats. "+
-		"Available formats are: cyclonedx1.4+json, cyclonedx1.4+xml, spdx2.3+json")
+		"Available formats are: cyclonedx1.4+json, cyclonedx1.4+xml, cyclonedx1.5+json, cyclonedx1.5+xml, spdx2.3+json")
+}
+
+func TestValidateSBOMFormat_ValidFormats(t *testing.T) {
+	logger := log.New(&bytes.Buffer{}, "", 0)
+	errFactory := errors.NewErrorFactory(logger)
+
+	tc := []string{
+		"cyclonedx1.4+json",
+		"cyclonedx1.4+xml",
+		"cyclonedx1.5+json",
+		"cyclonedx1.5+xml",
+		"spdx2.3+json",
+	}
+
+	for _, tt := range tc {
+		t.Run(tt, func(t *testing.T) {
+			err := ValidateSBOMFormat(errFactory, tt)
+			assert.NoError(t, err)
+		})
+	}
 }

--- a/pkg/sbom/sbom_test.go
+++ b/pkg/sbom/sbom_test.go
@@ -81,7 +81,7 @@ func TestSBOMWorkflow_InvalidFormat(t *testing.T) {
 	_, err := sbom.SBOMWorkflow(mockICTX, []workflow.Data{})
 
 	assert.ErrorContains(t, err, "The format provided (cyclonedx+json) is not one of the available formats. "+
-		"Available formats are: cyclonedx1.4+json, cyclonedx1.4+xml, spdx2.3+json")
+		"Available formats are: cyclonedx1.4+json, cyclonedx1.4+xml, cyclonedx1.5+json, cyclonedx1.5+xml, spdx2.3+json")
 }
 
 func TestSBOMWorkflow_NoOrgID(t *testing.T) {


### PR DESCRIPTION
This adds formats `cyclonedx1.5+json`, `cyclonedx1.5+xml` to the CLI as available formats when generating SBOMs on the fly.