### PR TITLE
feat: add initial presenter for sbom test cmd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/snyk/cli-extension-sbom
 go 1.19
 
 require (
+	github.com/bradleyjkemp/cupaloy/v2 v2.8.0
 	github.com/golang/mock v1.6.0
 	github.com/snyk/go-application-framework v0.0.0-20231116141714-376c41e7746c
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74 h1:Kk6a4nehpJ3UuJRqlA3JxYxBZEqCeOmATOvrbT4p9RA=
 github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
+github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
+github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -210,11 +212,13 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.13.0 h1:BWSJ/M+f+3nmdz9bxB+bWX28kkALN2ok11D0rSo8EJU=
 github.com/spf13/viper v1.13.0/go.mod h1:Icm2xNL3/8uyh/wFuB1jI7TiTNKp8632Nwegu+zgdYw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=

--- a/internal/commands/sbomtest/presenter.go
+++ b/internal/commands/sbomtest/presenter.go
@@ -1,0 +1,77 @@
+//nolint:tagliatelle // Disabling for snake-case in JSON payloads.
+package sbomtest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/snyk/go-application-framework/pkg/workflow"
+)
+
+type presenterFormat int
+
+const (
+	PresenterFormatPretty presenterFormat = iota
+	PresenterFormatJSON
+
+	MIMETypeJSON = "application/json"
+	MIMETypeText = "text/plain"
+)
+
+type Presenter struct {
+	format presenterFormat
+}
+
+func newPresenter(ictx workflow.InvocationContext) *Presenter {
+	f := PresenterFormatPretty
+
+	if ictx.GetConfiguration().GetBool("json") {
+		f = PresenterFormatJSON
+	}
+
+	return &Presenter{
+		format: f,
+	}
+}
+
+// TODO: this is just a temporary type def which should get replaced
+// with a definition from the SBOM Test Client.
+type TestResult struct {
+	Summary TestSummary `json:"summary"`
+}
+type TestSummary struct {
+	TotalVulnerabilities int `json:"total_vulnerabilities"`
+}
+
+func (p Presenter) Render(result TestResult) (data []byte, contentType string, err error) {
+	switch p.format {
+	default:
+		return nil, "", errors.New("presenter has no format")
+	case PresenterFormatJSON:
+		return renderJSONResult(result)
+	case PresenterFormatPretty:
+		return renderPrettyResult(result)
+	}
+}
+
+func renderJSONResult(result TestResult) (data []byte, contentType string, err error) {
+	contentType = MIMETypeJSON
+
+	data, err = json.Marshal(result)
+	if err != nil {
+		return nil, contentType, err
+	}
+
+	return data, contentType, nil
+}
+
+func renderPrettyResult(result TestResult) (data []byte, contentType string, err error) {
+	// TODO: this is a mock template. Should get replaced.
+	tpl := `TEST RESULTS
+------------
+❌ Found a total of %d vulnerabilities
+`
+
+	return []byte(fmt.Sprintf(tpl, result.Summary.TotalVulnerabilities)), MIMETypeText, nil
+}

--- a/internal/commands/sbomtest/presenter_test.go
+++ b/internal/commands/sbomtest/presenter_test.go
@@ -1,0 +1,41 @@
+package sbomtest_test
+
+import (
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy/v2"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-sbom/internal/commands/sbomtest"
+)
+
+var snapshotter = cupaloy.New(cupaloy.SnapshotSubdirectory("testdata/snapshots"))
+
+func TestPresenter_Pretty(t *testing.T) {
+	mockICTX := createMockICTX(t)
+	mockICTX.GetConfiguration().Set("experimental", true)
+
+	data, err := sbomtest.TestWorkflow(mockICTX, []workflow.Data{})
+
+	require.NoError(t, err)
+	require.Len(t, data, 1)
+
+	assert.Equal(t, "text/plain", data[0].GetContentType())
+	snapshotter.SnapshotT(t, data[0].GetPayload())
+}
+
+func TestPresenter_JSON(t *testing.T) {
+	mockICTX := createMockICTX(t)
+	mockICTX.GetConfiguration().Set("experimental", true)
+	mockICTX.GetConfiguration().Set("json", true)
+
+	data, err := sbomtest.TestWorkflow(mockICTX, []workflow.Data{})
+
+	require.NoError(t, err)
+	require.Len(t, data, 1)
+
+	assert.Equal(t, "application/json", data[0].GetContentType())
+	snapshotter.SnapshotT(t, data[0].GetPayload())
+}

--- a/internal/commands/sbomtest/sbomtest.go
+++ b/internal/commands/sbomtest/sbomtest.go
@@ -37,5 +37,15 @@ func TestWorkflow(
 
 	logger.Println("SBOM workflow test with file:", filename)
 
-	return []workflow.Data{}, nil
+	mockResult := TestResult{ // TODO: assign the actual test result
+		Summary: TestSummary{TotalVulnerabilities: 42},
+	}
+	data, contentType, err := newPresenter(ictx).Render(mockResult)
+
+	return []workflow.Data{workflowData(data, contentType)}, err
+}
+
+func workflowData(data []byte, contentType string) workflow.Data {
+	id := workflow.NewTypeIdentifier(WorkflowID, "sbom.test")
+	return workflow.NewDataFromInput(nil, id, contentType, data)
 }

--- a/internal/commands/sbomtest/testdata/snapshots/TestPresenter_JSON
+++ b/internal/commands/sbomtest/testdata/snapshots/TestPresenter_JSON
@@ -1,0 +1,1 @@
+{"summary":{"total_vulnerabilities":42}}

--- a/internal/commands/sbomtest/testdata/snapshots/TestPresenter_Pretty
+++ b/internal/commands/sbomtest/testdata/snapshots/TestPresenter_Pretty
@@ -1,0 +1,4 @@
+TEST RESULTS
+------------
+❌ Found a total of 42 vulnerabilities
+


### PR DESCRIPTION
This adds a first presenter implementation to the `sbom test` command. The JSON format pretty much just encodes and prints a JSON string; the pretty format uses some string template and injects values. This is just a rough placeholder for the actual test results.