### PR TITLE
fix: send requests from sbomclient as JSON:API

### DIFF
--- a/internal/snykclient/snykclient.go
+++ b/internal/snykclient/snykclient.go
@@ -1,11 +1,10 @@
 package snykclient
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -48,17 +47,10 @@ func NewSnykClient(c *http.Client, apiBaseURL, orgID string) *SnykClient {
 	}
 }
 
-var JsonAPIPrefixBytes = []byte(`{"data":{"type":"sbom_test","attributes":{"sbom":`)
-var JsonAPISuffixBytes = []byte(`}}}`)
-
-func (t *SnykClient) CreateSBOMTest(ctx context.Context, sbomJSON io.Reader) (*SBOMTest, error) {
+func (t *SnykClient) CreateSBOMTest(ctx context.Context, sbomJSON []byte) (*SBOMTest, error) {
 	url := fmt.Sprintf("%s/rest/orgs/%s/sbom_tests?version=%s", t.apiBaseURL, t.orgID, sbomTestAPIVersion)
 
-	jsonAPIReader := io.MultiReader(
-		bytes.NewReader(JsonAPIPrefixBytes),
-		sbomJSON,
-		bytes.NewReader(JsonAPISuffixBytes),
-	)
+	jsonAPIReader := strings.NewReader(fmt.Sprintf(`{"data":{"type":"sbom_test","attributes":{"sbom":%s}}}`, sbomJSON))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, jsonAPIReader)
 	if err != nil {


### PR DESCRIPTION
Updates the `SnykClient` to send the SBOM JSON wrapped in JSON:API.

This keeps the sending of the SBOM as an `io.Reader` rather than reading the file into memory to construct the JSON:API request. This is achieved by wrapping the JSON:API prefix & suffix bytes along with the SBOM JSON `io.Reader` in a `io.MultiReader`.