### PR TITLE
feat: load sbom file

### DIFF
--- a/internal/commands/sbomtest/presenter_test.go
+++ b/internal/commands/sbomtest/presenter_test.go
@@ -16,6 +16,7 @@ var snapshotter = cupaloy.New(cupaloy.SnapshotSubdirectory("testdata/snapshots")
 func TestPresenter_Pretty(t *testing.T) {
 	mockICTX := createMockICTX(t)
 	mockICTX.GetConfiguration().Set("experimental", true)
+	mockICTX.GetConfiguration().Set("file", "testdata/bom.json")
 
 	data, err := sbomtest.TestWorkflow(mockICTX, []workflow.Data{})
 
@@ -30,6 +31,7 @@ func TestPresenter_JSON(t *testing.T) {
 	mockICTX := createMockICTX(t)
 	mockICTX.GetConfiguration().Set("experimental", true)
 	mockICTX.GetConfiguration().Set("json", true)
+	mockICTX.GetConfiguration().Set("file", "testdata/bom.json")
 
 	data, err := sbomtest.TestWorkflow(mockICTX, []workflow.Data{})
 

--- a/internal/commands/sbomtest/sbomloader.go
+++ b/internal/commands/sbomtest/sbomloader.go
@@ -1,30 +1,27 @@
 package sbomtest
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
-	"strings"
 )
 
-// IsSBOMJSON checks that a reader looks like it could be a SBOM JSON file.
-// It only looks at the first 64 bytes of the reader. It then Trims the whitespace
-// and checks if the first character is a '{'. '[' would not be a valid SBOM JSON file.
-// This is a very basic check and avoids having to load the entire file into memory.
-func IsSBOMJSON(r io.Reader) bool {
-	var buf [64]byte
-	n, err := r.Read(buf[:])
-	if err != nil && err != io.EOF {
+func IsSBOMJSON(b []byte) bool {
+	var sbom interface{}
+	err := json.Unmarshal(b, &sbom)
+	if err != nil {
 		return false
 	}
 
-	str := strings.TrimSpace(string(buf[:n]))
+	if _, ok := sbom.(map[string]interface{}); !ok {
+		return false
+	}
 
-	return strings.HasPrefix(str, "{")
+	return true
 }
 
-func openFile(filename string) (*os.File, error) {
+func ReadSBOMFile(filename string) ([]byte, error) {
 	// Check if file exists
 	info, err := os.Stat(filename)
 	if err != nil {
@@ -39,27 +36,17 @@ func openFile(filename string) (*os.File, error) {
 		return nil, errors.New("file is a directory")
 	}
 
-	// Check if the user has permission to access the file
-	file, err := os.Open(filename)
+	// Open file and read it
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, errors.New("failed to open file: " + err.Error())
 	}
 
-	return file, nil
-}
-
-func OpenSBOMFile(filename string) (*os.File, error) {
-	file, err := openFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	isValidSBOM := IsSBOMJSON(file)
+	isValidSBOM := IsSBOMJSON(b)
 
 	if !isValidSBOM {
 		return nil, fmt.Errorf("file is not a supported SBOM format")
 	}
 
-	return openFile(filename)
+	return b, nil
 }

--- a/internal/commands/sbomtest/sbomloader.go
+++ b/internal/commands/sbomtest/sbomloader.go
@@ -8,17 +8,9 @@ import (
 )
 
 func IsSBOMJSON(b []byte) bool {
-	var sbom interface{}
+	var sbom map[string]interface{}
 	err := json.Unmarshal(b, &sbom)
-	if err != nil {
-		return false
-	}
-
-	if _, ok := sbom.(map[string]interface{}); !ok {
-		return false
-	}
-
-	return true
+	return err == nil
 }
 
 func ReadSBOMFile(filename string) ([]byte, error) {

--- a/internal/commands/sbomtest/sbomloader.go
+++ b/internal/commands/sbomtest/sbomloader.go
@@ -1,0 +1,52 @@
+package sbomtest
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+)
+
+func IsSupportedSBOMFormat(inputFile io.Reader) (bool, error) {
+	input, err := io.ReadAll(inputFile)
+	if err != nil {
+		return false, err
+	}
+	if bytes.Contains(input, []byte("CycloneDX")) && bytes.Contains(input, []byte("bomFormat")) {
+		return true, nil
+	}
+
+	if bytes.Contains(input, []byte("cyclonedx")) && bytes.Contains(input, []byte("xmlns")) {
+		return true, nil
+	}
+
+	if bytes.Contains(input, []byte("SPDXRef-DOCUMENT")) && bytes.Contains(input, []byte(`"spdxVersion"`)) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func OpenFile(filename string) (*os.File, error) {
+	// Check if file exists
+	info, err := os.Stat(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errors.New("file does not exist")
+		}
+		return nil, errors.New("failed to get file info")
+	}
+
+	// Check if it's a directory
+	if info.IsDir() {
+		return nil, errors.New("file is a directory")
+	}
+
+	// Check if the user has permission to access the file
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, errors.New("failed to open file: " + err.Error())
+	}
+
+	return file, nil
+}

--- a/internal/commands/sbomtest/sbomloader_test.go
+++ b/internal/commands/sbomtest/sbomloader_test.go
@@ -2,7 +2,6 @@ package sbomtest_test
 
 import (
 	_ "embed"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -44,6 +43,12 @@ func TestIsSBOMJSON(t *testing.T) {
 			expectedResult: false,
 		},
 		{
+			name: "is ndjson",
+			content: `{"foo":"bar"},
+{"boo":"baz"}`,
+			expectedResult: false,
+		},
+		{
 			name:           "is string",
 			content:        `I am a string`,
 			expectedResult: false,
@@ -57,7 +62,7 @@ func TestIsSBOMJSON(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(tt *testing.T) {
-			r := strings.NewReader(tc.content)
+			r := []byte(tc.content)
 
 			ok := sbomtest.IsSBOMJSON(r)
 
@@ -66,22 +71,29 @@ func TestIsSBOMJSON(t *testing.T) {
 	}
 }
 
-func TestOpenFile_FileDoesNotExist(t *testing.T) {
+func TestReadSBOMFile_FileDoesNotExist(t *testing.T) {
 	filename := "testdata/this-file-does-not-exist.txt"
 
-	reader, err := sbomtest.OpenSBOMFile(filename)
+	sbomContent, err := sbomtest.ReadSBOMFile(filename)
 
 	require.Error(t, err)
 	require.Equal(t, "file does not exist", err.Error())
-	require.Nil(t, reader)
+	require.Nil(t, sbomContent)
 }
 
-func TestOpenFile_FileIsDirectory(t *testing.T) {
+func TestReadSBOMFile_FileIsDirectory(t *testing.T) {
 	folder := "testdata"
 
-	reader, err := sbomtest.OpenSBOMFile(folder)
+	sbomContent, err := sbomtest.ReadSBOMFile(folder)
 
 	require.Error(t, err)
 	require.Equal(t, "file is a directory", err.Error())
-	require.Nil(t, reader)
+	require.Nil(t, sbomContent)
+}
+
+func TestReadSBOMSuccessfully(t *testing.T) {
+	sbomContent, err := sbomtest.ReadSBOMFile("testdata/bom.json")
+
+	require.NoError(t, err)
+	require.Equal(t, sbomJson, string(sbomContent))
 }

--- a/internal/commands/sbomtest/sbomloader_test.go
+++ b/internal/commands/sbomtest/sbomloader_test.go
@@ -1,0 +1,61 @@
+package sbomtest_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-sbom/internal/commands/sbomtest"
+)
+
+func TestIsSupportedSBOMFormat_Success(t *testing.T) {
+	testCases := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "Test is cyclonedx json supported",
+			content: "CycloneDX/bomFormat",
+		},
+		{
+			name:    "Test is cyclonedx xml supported",
+			content: "cyclonedx/xmlns",
+		},
+		{
+			name:    "Test is spdx supported",
+			content: `SPDXRef-DOCUMENT/"spdxVersion"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			reader := strings.NewReader(tc.content)
+
+			ok, err := sbomtest.IsSupportedSBOMFormat(reader)
+
+			require.NoError(t, err)
+			require.True(t, ok)
+		})
+	}
+}
+
+func TestOpenFile_FileDoesNotExist(t *testing.T) {
+	filename := "testdata/this-file-does-not-exist.txt"
+
+	reader, err := sbomtest.OpenFile(filename)
+
+	require.Error(t, err)
+	require.Equal(t, "file does not exist", err.Error())
+	require.Nil(t, reader)
+}
+
+func TestOpenFile_FileIsDirectory(t *testing.T) {
+	folder := "testdata"
+
+	reader, err := sbomtest.OpenFile(folder)
+
+	require.Error(t, err)
+	require.Equal(t, "file is a directory", err.Error())
+	require.Nil(t, reader)
+}

--- a/internal/commands/sbomtest/sbomloader_test.go
+++ b/internal/commands/sbomtest/sbomloader_test.go
@@ -11,20 +11,58 @@ import (
 
 func TestIsSupportedSBOMFormat_Success(t *testing.T) {
 	testCases := []struct {
-		name    string
-		content string
+		name           string
+		content        string
+		expectedResult bool
 	}{
 		{
-			name:    "Test is cyclonedx json supported",
-			content: "CycloneDX/bomFormat",
+			name:           "Test is cyclonedx json supported",
+			content:        "CycloneDX/bomFormat",
+			expectedResult: true,
 		},
 		{
-			name:    "Test is cyclonedx xml supported",
-			content: "cyclonedx/xmlns",
+			name:           "Test is cyclonedx xml is not supported",
+			content:        "cyclonedx/xmlns",
+			expectedResult: false,
 		},
 		{
-			name:    "Test is spdx supported",
-			content: `SPDXRef-DOCUMENT/"spdxVersion"`,
+			name:           "Test is spdx supported",
+			content:        `SPDXRef-DOCUMENT/"spdxVersion"`,
+			expectedResult: true,
+		},
+		{
+			name: "Document not supported",
+			content: `Lorem ipsum dolor sit amet,
+						consectetur adipiscing elit,
+						sed do eiusmod tempor incididunt ut labore et dolore magna aliqua`,
+			expectedResult: false,
+		},
+		{
+			name:           "Test is not spdx - missing version",
+			content:        `SPDXRef-DOCUMENT`,
+			expectedResult: false,
+		},
+		{
+			name:           "Test is not spdx - missing document",
+			content:        `"spdxVersion"`,
+			expectedResult: false,
+		},
+		{
+			name:           "Test is not cyclonedx json - missing format",
+			content:        "CycloneDX",
+			expectedResult: false,
+		},
+		{
+			name:           "Test is not cyclonedx json - missing document",
+			content:        "bomFormat",
+			expectedResult: false,
+		},
+		{
+			name: "Test is cyclonedx matches over multiple lines",
+			content: `CycloneDX
+								asdf
+								bomFormat`,
+			expectedResult: true,
 		},
 	}
 
@@ -35,7 +73,7 @@ func TestIsSupportedSBOMFormat_Success(t *testing.T) {
 			ok, err := sbomtest.IsSupportedSBOMFormat(reader)
 
 			require.NoError(t, err)
-			require.True(t, ok)
+			require.Equal(t, tc.expectedResult, ok)
 		})
 	}
 }

--- a/internal/commands/sbomtest/sbomtest.go
+++ b/internal/commands/sbomtest/sbomtest.go
@@ -35,6 +35,15 @@ func TestWorkflow(
 		return nil, fmt.Errorf("experimental flag not set")
 	}
 
+	if filename == "" {
+		return nil, fmt.Errorf("file flag not set")
+	}
+
+	_, err := OpenFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
 	logger.Println("SBOM workflow test with file:", filename)
 
 	mockResult := TestResult{ // TODO: assign the actual test result

--- a/internal/commands/sbomtest/sbomtest.go
+++ b/internal/commands/sbomtest/sbomtest.go
@@ -39,10 +39,11 @@ func TestWorkflow(
 		return nil, fmt.Errorf("file flag not set")
 	}
 
-	_, err := OpenFile(filename)
+	file, err := OpenSBOMFile(filename)
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 
 	logger.Println("SBOM workflow test with file:", filename)
 

--- a/internal/commands/sbomtest/sbomtest.go
+++ b/internal/commands/sbomtest/sbomtest.go
@@ -39,11 +39,10 @@ func TestWorkflow(
 		return nil, fmt.Errorf("file flag not set")
 	}
 
-	file, err := OpenSBOMFile(filename)
+	_, err := ReadSBOMFile(filename)
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
 
 	logger.Println("SBOM workflow test with file:", filename)
 

--- a/internal/commands/sbomtest/sbomtest_test.go
+++ b/internal/commands/sbomtest/sbomtest_test.go
@@ -25,9 +25,29 @@ func TestSBOMTestWorkflow_NoExperimentalFlag(t *testing.T) {
 	assert.ErrorContains(t, err, "experimental flag not set")
 }
 
-func TestSBOMTestWorkflow_SupplyExperimentalFlag(t *testing.T) {
+func TestSBOMTestWorkflow_NoFileFlag(t *testing.T) {
 	mockICTX := createMockICTX(t)
 	mockICTX.GetConfiguration().Set("experimental", true)
+
+	_, err := sbomtest.TestWorkflow(mockICTX, []workflow.Data{})
+
+	assert.ErrorContains(t, err, "file flag not set")
+}
+
+func TestSBOMTestWorkflow_SupplyMissingFile(t *testing.T) {
+	mockICTX := createMockICTX(t)
+	mockICTX.GetConfiguration().Set("experimental", true)
+	mockICTX.GetConfiguration().Set("file", "missing-file.txt")
+
+	_, err := sbomtest.TestWorkflow(mockICTX, []workflow.Data{})
+
+	assert.ErrorContains(t, err, "file does not exist")
+}
+
+func TestSBOMTestWorkflow_Success(t *testing.T) {
+	mockICTX := createMockICTX(t)
+	mockICTX.GetConfiguration().Set("experimental", true)
+	mockICTX.GetConfiguration().Set("file", "testdata/bom.json")
 
 	_, err := sbomtest.TestWorkflow(mockICTX, []workflow.Data{})
 

--- a/internal/commands/sbomtest/testdata/bom.json
+++ b/internal/commands/sbomtest/testdata/bom.json
@@ -1,0 +1,44 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuid:78933f9a-cf34-45a0-bfef-b8201b8e1ab9",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2023-10-05T15:21:44+02:00",
+    "tools": [
+      {
+        "vendor": "CycloneDX",
+        "name": "cyclonedx-gomod",
+        "version": "v1.4.0",
+        "externalReferences": [
+          {
+            "url": "https://github.com/CycloneDX/cyclonedx-gomod",
+            "type": "vcs"
+          },
+          {
+            "url": "https://cyclonedx.org",
+            "type": "website"
+          }
+        ]
+      }
+    ],
+    "component": {
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.3?type=module",
+      "type": "application",
+      "name": "gopkg.in/yaml.v2",
+      "version": "v2.2.3",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.3?type=module\u0026goos=darwin\u0026goarch=arm64",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-yaml/yaml",
+          "type": "vcs"
+        }
+      ]
+    }
+  },
+  "dependencies": [
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.3?type=module"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the ability to open and validate a SBOM via the `OpenSBOMFile` function.

The `OpenSBOMFile` will check for the following:

- The SBOM file exists
- The SBOM file is not a directory
- We have permission to open the SBOM file
- The SBOM file is a supported JSON SBOM file