### PR TITLE
fix: decouple presenter tests

### DIFF
--- a/internal/commands/sbomtest/presenter.go
+++ b/internal/commands/sbomtest/presenter.go
@@ -20,7 +20,7 @@ const (
 )
 
 type Presenter struct {
-	format presenterFormat
+	Format presenterFormat
 }
 
 func newPresenter(ictx workflow.InvocationContext) *Presenter {
@@ -31,7 +31,7 @@ func newPresenter(ictx workflow.InvocationContext) *Presenter {
 	}
 
 	return &Presenter{
-		format: f,
+		Format: f,
 	}
 }
 
@@ -45,7 +45,7 @@ type TestSummary struct {
 }
 
 func (p Presenter) Render(result TestResult) (data []byte, contentType string, err error) {
-	switch p.format {
+	switch p.Format {
 	default:
 		return nil, "", errors.New("presenter has no format")
 	case PresenterFormatJSON:

--- a/internal/commands/sbomtest/presenter_test.go
+++ b/internal/commands/sbomtest/presenter_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy/v2"
-	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -13,31 +12,30 @@ import (
 
 var snapshotter = cupaloy.New(cupaloy.SnapshotSubdirectory("testdata/snapshots"))
 
-func TestPresenter_Pretty(t *testing.T) {
-	mockICTX := createMockICTX(t)
-	mockICTX.GetConfiguration().Set("experimental", true)
-	mockICTX.GetConfiguration().Set("file", "testdata/bom.json")
+var mockResult = sbomtest.TestResult{ // TODO: assign the actual test result
+	Summary: sbomtest.TestSummary{TotalVulnerabilities: 42},
+}
 
-	data, err := sbomtest.TestWorkflow(mockICTX, []workflow.Data{})
+func TestPresenter_Pretty(t *testing.T) {
+	presenter := &sbomtest.Presenter{
+		Format: sbomtest.PresenterFormatPretty,
+	}
+
+	data, contentType, err := presenter.Render(mockResult)
 
 	require.NoError(t, err)
-	require.Len(t, data, 1)
-
-	assert.Equal(t, "text/plain", data[0].GetContentType())
-	snapshotter.SnapshotT(t, data[0].GetPayload())
+	assert.Equal(t, "text/plain", contentType)
+	snapshotter.SnapshotT(t, data)
 }
 
 func TestPresenter_JSON(t *testing.T) {
-	mockICTX := createMockICTX(t)
-	mockICTX.GetConfiguration().Set("experimental", true)
-	mockICTX.GetConfiguration().Set("json", true)
-	mockICTX.GetConfiguration().Set("file", "testdata/bom.json")
+	presenter := &sbomtest.Presenter{
+		Format: sbomtest.PresenterFormatJSON,
+	}
 
-	data, err := sbomtest.TestWorkflow(mockICTX, []workflow.Data{})
+	data, contentType, err := presenter.Render(mockResult)
 
 	require.NoError(t, err)
-	require.Len(t, data, 1)
-
-	assert.Equal(t, "application/json", data[0].GetContentType())
-	snapshotter.SnapshotT(t, data[0].GetPayload())
+	assert.Equal(t, "application/json", contentType)
+	snapshotter.SnapshotT(t, data)
 }


### PR DESCRIPTION
This decouples the existing presenter tests from the SBOM test workflow command.