### PR TITLE
refactor: keep presenter format private

### DIFF
--- a/internal/commands/sbomtest/presenter.go
+++ b/internal/commands/sbomtest/presenter.go
@@ -20,10 +20,10 @@ const (
 )
 
 type Presenter struct {
-	Format presenterFormat
+	format presenterFormat
 }
 
-func newPresenter(ictx workflow.InvocationContext) *Presenter {
+func NewPresenter(ictx workflow.InvocationContext) *Presenter {
 	f := PresenterFormatPretty
 
 	if ictx.GetConfiguration().GetBool("json") {
@@ -31,7 +31,7 @@ func newPresenter(ictx workflow.InvocationContext) *Presenter {
 	}
 
 	return &Presenter{
-		Format: f,
+		format: f,
 	}
 }
 
@@ -45,7 +45,7 @@ type TestSummary struct {
 }
 
 func (p Presenter) Render(result TestResult) (data []byte, contentType string, err error) {
-	switch p.Format {
+	switch p.format {
 	default:
 		return nil, "", errors.New("presenter has no format")
 	case PresenterFormatJSON:

--- a/internal/commands/sbomtest/presenter_test.go
+++ b/internal/commands/sbomtest/presenter_test.go
@@ -17,9 +17,9 @@ var mockResult = sbomtest.TestResult{ // TODO: assign the actual test result
 }
 
 func TestPresenter_Pretty(t *testing.T) {
-	presenter := &sbomtest.Presenter{
-		Format: sbomtest.PresenterFormatPretty,
-	}
+	mockICTX := createMockICTX(t)
+	mockICTX.GetConfiguration().Set("json", false)
+	presenter := sbomtest.NewPresenter(mockICTX)
 
 	data, contentType, err := presenter.Render(mockResult)
 
@@ -29,9 +29,9 @@ func TestPresenter_Pretty(t *testing.T) {
 }
 
 func TestPresenter_JSON(t *testing.T) {
-	presenter := &sbomtest.Presenter{
-		Format: sbomtest.PresenterFormatJSON,
-	}
+	mockICTX := createMockICTX(t)
+	mockICTX.GetConfiguration().Set("json", true)
+	presenter := sbomtest.NewPresenter(mockICTX)
 
 	data, contentType, err := presenter.Render(mockResult)
 

--- a/internal/commands/sbomtest/sbomtest.go
+++ b/internal/commands/sbomtest/sbomtest.go
@@ -49,7 +49,7 @@ func TestWorkflow(
 	mockResult := TestResult{ // TODO: assign the actual test result
 		Summary: TestSummary{TotalVulnerabilities: 42},
 	}
-	data, contentType, err := newPresenter(ictx).Render(mockResult)
+	data, contentType, err := NewPresenter(ictx).Render(mockResult)
 
 	return []workflow.Data{workflowData(data, contentType)}, err
 }


### PR DESCRIPTION
This PR makes the Presenter `format` property private so it can't be mutated.