### PR TITLE
feat: move errFactory out of parseResponse function

### DIFF
--- a/internal/snykclient/helpers.go
+++ b/internal/snykclient/helpers.go
@@ -6,11 +6,9 @@ import (
 	"io"
 	"net/http"
 	"strings"
-
-	"github.com/snyk/cli-extension-sbom/internal/errors"
 )
 
-func parseResponse(rsp *http.Response, expectedStatusCode int, expectedDocument interface{}, errFactory *errors.ErrorFactory) error {
+func parseResponse(rsp *http.Response, expectedStatusCode int, expectedDocument interface{}) error {
 	body, err := io.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
@@ -19,14 +17,14 @@ func parseResponse(rsp *http.Response, expectedStatusCode int, expectedDocument 
 
 	if rsp.StatusCode != expectedStatusCode {
 		var errorDoc errorDocument
-		if err = json.Unmarshal(body, &errorDoc); err != nil {
+		if err := json.Unmarshal(body, &errorDoc); err != nil {
 			// If the error is not encoded as JSON, that is less important a detail to
 			// surface to the user than the actual content of the error. Notably, this
 			// can occur when cerberus bounces the request, as it returns plain text
 			// bodies.
-			return errFactory.NewInternalError(err)
+			return err
 		}
-		return errFactory.NewInternalError(fmt.Errorf("%s", errorDocumentToString(errorDoc)))
+		return fmt.Errorf("%s", errorDocumentToString(errorDoc))
 	}
 	if expectedDocument != nil {
 		return json.Unmarshal(body, expectedDocument)

--- a/internal/snykclient/snykclient.go
+++ b/internal/snykclient/snykclient.go
@@ -66,8 +66,8 @@ func (t *SnykClient) CreateSBOMTest(ctx context.Context, sbomJSON []byte, errFac
 	}
 
 	var body SBOMTestResourceDocument
-	if err := parseResponse(rsp, http.StatusCreated, &body, errFactory); err != nil {
-		return nil, err
+	if err := parseResponse(rsp, http.StatusCreated, &body); err != nil {
+		return nil, errFactory.NewInternalError(err)
 	}
 
 	return &SBOMTest{
@@ -88,8 +88,8 @@ func (t *SBOMTest) GetResult(ctx context.Context, errFactory *errors.ErrorFactor
 	}
 
 	var body SBOMTestResultResourceDocument
-	if err := parseResponse(resp, http.StatusOK, &body, errFactory); err != nil {
-		return nil, err
+	if err := parseResponse(resp, http.StatusOK, &body); err != nil {
+		return nil, errFactory.NewInternalError(err)
 	}
 
 	return body.AsResult(), nil
@@ -117,8 +117,8 @@ func (t *SBOMTest) GetStatus(ctx context.Context, errFactory *errors.ErrorFactor
 	}
 
 	var body SBOMTestStatusResourceDocument
-	if err := parseResponse(resp, http.StatusOK, &body, errFactory); err != nil {
-		return SBOMTestStatusIndeterminate, err
+	if err := parseResponse(resp, http.StatusOK, &body); err != nil {
+		return SBOMTestStatusIndeterminate, errFactory.NewInternalError(err)
 	}
 	if body.Data.Attributes.Status == "error" {
 		return SBOMTestStatusError, nil


### PR DESCRIPTION
Move `errFactory` one level up out of `parseResponse` function to catch all its errors under a `NewInternalError`. The motivation was catching some errors which were not wrapped i.e https://github.com/snyk/cli-extension-sbom/blob/9347cb700fdca8fd37af703147ccc28cea66c973/internal/snykclient/helpers.go#L17 and https://github.com/snyk/cli-extension-sbom/blob/9347cb700fdca8fd37af703147ccc28cea66c973/internal/snykclient/helpers.go#L32