### PR TITLE
fix: error messages

### DIFF
--- a/internal/commands/sbomtest/sbomtest.go
+++ b/internal/commands/sbomtest/sbomtest.go
@@ -103,7 +103,7 @@ func TestWorkflow(
 
 	summaryData, summaryContentType, err := BuildTestSummary(results.Summary)
 	if err != nil {
-		return nil, errFactory.NewInternalError(err)
+		return nil, errFactory.NewFatalSBOMTestError(err)
 	}
 
 	return []workflow.Data{workflowData(buf.Bytes(), ct), workflowData(summaryData, summaryContentType)}, err

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -39,7 +39,7 @@ func (ef *ErrorFactory) newErr(err error, userMsg string) *SBOMExtensionError {
 	}
 }
 
-func (ef *ErrorFactory) NewInternalError(err error) *SBOMExtensionError {
+func (ef *ErrorFactory) NewFatalSBOMGenerationError(err error) *SBOMExtensionError {
 	return ef.newErr(
 		err,
 		"An error occurred while running the underlying analysis which is required to generate the SBOM. "+
@@ -47,7 +47,7 @@ func (ef *ErrorFactory) NewInternalError(err error) *SBOMExtensionError {
 	)
 }
 
-func (ef *ErrorFactory) NewRemoteError(err error) *SBOMExtensionError {
+func (ef *ErrorFactory) NewRemoteGenerationError(err error) *SBOMExtensionError {
 	return ef.newErr(
 		err,
 		"An error occurred while generating the SBOM. "+
@@ -93,7 +93,7 @@ func (ef *ErrorFactory) NewInvalidFormatError(invalid string, available []string
 	)
 }
 
-func (ef *ErrorFactory) NewBadRequestError(err error) *SBOMExtensionError {
+func (ef *ErrorFactory) NewBadRequestGenerationError(err error) *SBOMExtensionError {
 	return ef.newErr(
 		err,
 		"SBOM generation failed due to bad input arguments. "+

--- a/internal/snykclient/snykclient_test.go
+++ b/internal/snykclient/snykclient_test.go
@@ -218,7 +218,7 @@ func TestSBOMTest_WaitUntilCompleteErrors(t *testing.T) {
 
 	err := sbomTest.WaitUntilCompleteWithBackoff(context.Background(), backoff, errFactory)
 
-	assert.ErrorContains(t, err, "An error occurred while running the underlying analysis which is required to generate the SBOM. "+
-		"Should this issue persist, please reach out to customer support.")
+	assert.ErrorContains(t, err, "Failed to test SBOM. There was an error when trying to test your SBOM,retrying may resolve the issue. "+
+		"If the error still occurs, contact support.")
 	assert.Equal(t, numRequests, 6)
 }


### PR DESCRIPTION
Use the appropriate error messages for the `sbom test` command, and rename the generation error variables to include the context.