### PR TITLE
wip: improvements in file error handling

### DIFF
--- a/internal/commands/sbomtest/sbomloader.go
+++ b/internal/commands/sbomtest/sbomloader.go
@@ -18,7 +18,7 @@ func ReadSBOMFile(filename string, errFactory *errors.ErrorFactory) ([]byte, err
 	info, err := os.Stat(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, errFactory.NewMissingFilenameFlagError()
+			return nil, errFactory.NewInvalidFilePathError(err, filename)
 		}
 		return nil, errFactory.NewFailedToReadFileError(err)
 	}

--- a/internal/commands/sbomtest/sbomloader_test.go
+++ b/internal/commands/sbomtest/sbomloader_test.go
@@ -83,7 +83,7 @@ func TestReadSBOMFile_FileDoesNotExist(t *testing.T) {
 	sbomContent, err := sbomtest.ReadSBOMFile(filename, errFactory)
 
 	require.Error(t, err)
-	require.Equal(t, "Flag `--file` is required to execute this command. Value should point to a valid SBOM document.", err.Error())
+	require.Equal(t, "The given filepath \"testdata/this-file-does-not-exist.txt\" does not exist.", err.Error())
 	require.Nil(t, sbomContent)
 }
 

--- a/internal/commands/sbomtest/sbomtest_test.go
+++ b/internal/commands/sbomtest/sbomtest_test.go
@@ -48,7 +48,7 @@ func TestSBOMTestWorkflow_SupplyMissingFile(t *testing.T) {
 
 	_, err := sbomtest.TestWorkflow(mockICTX, []workflow.Data{})
 
-	assert.ErrorContains(t, err, "Flag `--file` is required to execute this command. Value should point to a valid SBOM document.")
+	assert.ErrorContains(t, err, "The given filepath \"missing-file.txt\" does not exist.")
 }
 
 func TestSBOMTestWorkflow_SuccessPretty(t *testing.T) {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -131,7 +131,7 @@ func (ef *ErrorFactory) IndeterminateWorkingDirectory(err error) *SBOMExtensionE
 
 func (ef *ErrorFactory) NewMissingExperimentalFlagError() *SBOMExtensionError {
 	return ef.newErr(
-		fmt.Errorf("exmperimental flag not set"),
+		fmt.Errorf("experimental flag not set"),
 		"Flag `--experimental` is required to execute this command.",
 	)
 }
@@ -174,4 +174,8 @@ func (ef *ErrorFactory) NewFatalSBOMTestError(err error) *SBOMExtensionError {
 		"Failed to test SBOM. There was an error when trying to test your SBOM,"+
 			"retrying may resolve the issue. If the error still occurs, contact support.",
 	)
+}
+
+func (ef *ErrorFactory) NewInvalidFilePathError(err error, path string) *SBOMExtensionError {
+	return ef.newErr(err, fmt.Sprintf("The given filepath %q does not exist.", path))
 }


### PR DESCRIPTION
Saw that when given an invalid filepath, error message says there was no filepath given at all. Also, fixed a typo.