### PR TITLE
fix: unwrap underlying error of SBOMExtensionError

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -20,6 +20,10 @@ func (xerr SBOMExtensionError) Error() string {
 	return xerr.userMsg
 }
 
+func (xerr SBOMExtensionError) Unwrap() error {
+	return xerr.err
+}
+
 type ErrorFactory struct {
 	logger *log.Logger
 }


### PR DESCRIPTION
This adds `SBOMExtensionError.Unwrap() error`