### PR TITLE
fix: unescape vulnerability titles

### DIFF
--- a/internal/view/issues.go
+++ b/internal/view/issues.go
@@ -3,8 +3,8 @@ package view
 import (
 	"bytes"
 	"fmt"
-	"html/template"
 	"slices"
+	"text/template"
 
 	"github.com/charmbracelet/lipgloss"
 

--- a/internal/view/issues_test.go
+++ b/internal/view/issues_test.go
@@ -68,6 +68,17 @@ func Test_generateIssues(t *testing.T) {
 			},
 			SnykRef: "SNYK-AMZN2-VIMMINIMAL-6062273",
 		},
+		OpenIssue{
+			Severity:    severities.LowSeverity,
+			Description: "Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')",
+			IntroducedBy: []IntroducedBy{
+				{
+					Name:    "dbt-core",
+					Version: "1.6.10",
+					PURL:    "pkg:pypi/dbt-core@1.6.10",
+				},
+			},
+		},
 	)
 
 	assert.NoError(t, err)

--- a/internal/view/summary.go
+++ b/internal/view/summary.go
@@ -3,9 +3,9 @@ package view
 import (
 	"bytes"
 	"fmt"
-	"html/template"
 	"strconv"
 	"strings"
+	"text/template"
 )
 
 type Summary struct {

--- a/internal/view/testdata/snapshots/Test_generateIssues
+++ b/internal/view/testdata/snapshots/Test_generateIssues
@@ -15,3 +15,7 @@
 [33m× [MEDIUM][0m [1mInteger Overflow or Wraparound[0m
   Introduced through: vim-minimal@9.0.1367-1.amzn2.0.1
   URL: https://security.snyk.io/vuln/SNYK-AMZN2-VIMMINIMAL-6062273
+
+× [LOW] [1mImproper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')[0m
+  Introduced through: pkg:pypi/dbt-core@1.6.10
+  URL: https://security.snyk.io/vuln/

--- a/internal/view/testresult.go
+++ b/internal/view/testresult.go
@@ -2,7 +2,7 @@ package view
 
 import (
 	"bytes"
-	"html/template"
+	"text/template"
 )
 
 type testResult struct {

--- a/internal/view/untested.go
+++ b/internal/view/untested.go
@@ -2,7 +2,7 @@ package view
 
 import (
 	"bytes"
-	"html/template"
+	"text/template"
 )
 
 type untestedComponents struct {


### PR DESCRIPTION
# What this does?
Unescapes the vulnerability titles, by rendering the pretty results using `text/template` package instead of `html/template`.
# Additional information
[https://snyksec.atlassian.net/browse/UNIFY-223](UNIFY-223)