### PR TITLE
add: cyclonedx 1.6 support

### DIFF
--- a/internal/commands/sbomcreate/sbomcreate_test.go
+++ b/internal/commands/sbomcreate/sbomcreate_test.go
@@ -83,7 +83,7 @@ func TestSBOMWorkflow_InvalidFormat(t *testing.T) {
 	_, err := sbomcreate.SBOMWorkflow(mockICTX, []workflow.Data{})
 
 	assert.ErrorContains(t, err, "The format provided (cyclonedx+json) is not one of the available formats. "+
-		"Available formats are: cyclonedx1.4+json, cyclonedx1.4+xml, cyclonedx1.5+json, cyclonedx1.5+xml, spdx2.3+json")
+		"Available formats are: cyclonedx1.4+json, cyclonedx1.4+xml, cyclonedx1.5+json, cyclonedx1.5+xml, cyclonedx1.6+json, cyclonedx1.6+xml, spdx2.3+json")
 }
 
 func TestSBOMWorkflow_NoOrgID(t *testing.T) {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -36,6 +36,8 @@ var sbomFormats = [...]string{
 	"cyclonedx1.4+xml",
 	"cyclonedx1.5+json",
 	"cyclonedx1.5+xml",
+	"cyclonedx1.6+json",
+	"cyclonedx1.6+xml",
 	"spdx2.3+json",
 }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -220,7 +220,7 @@ func TestValidateSBOMFormat_EmptyFormat(t *testing.T) {
 	errFactory := errors.NewErrorFactory(logger)
 	err := ValidateSBOMFormat(errFactory, "")
 	assert.ErrorContains(t, err, "Must set `--format` flag to specify an SBOM format. "+
-		"Available formats are: cyclonedx1.4+json, cyclonedx1.4+xml, cyclonedx1.5+json, cyclonedx1.5+xml, spdx2.3+json")
+		"Available formats are: cyclonedx1.4+json, cyclonedx1.4+xml, cyclonedx1.5+json, cyclonedx1.5+xml, cyclonedx1.6+json, cyclonedx1.6+xml, spdx2.3+json")
 }
 
 func TestValidateSBOMFormat_InvalidFormat(t *testing.T) {
@@ -228,7 +228,7 @@ func TestValidateSBOMFormat_InvalidFormat(t *testing.T) {
 	errFactory := errors.NewErrorFactory(logger)
 	err := ValidateSBOMFormat(errFactory, "not+a+format")
 	assert.ErrorContains(t, err, "The format provided (not+a+format) is not one of the available formats. "+
-		"Available formats are: cyclonedx1.4+json, cyclonedx1.4+xml, cyclonedx1.5+json, cyclonedx1.5+xml, spdx2.3+json")
+		"Available formats are: cyclonedx1.4+json, cyclonedx1.4+xml, cyclonedx1.5+json, cyclonedx1.5+xml, cyclonedx1.6+json, cyclonedx1.6+xml, spdx2.3+json")
 }
 
 func TestValidateSBOMFormat_ValidFormats(t *testing.T) {
@@ -240,6 +240,8 @@ func TestValidateSBOMFormat_ValidFormats(t *testing.T) {
 		"cyclonedx1.4+xml",
 		"cyclonedx1.5+json",
 		"cyclonedx1.5+xml",
+		"cyclonedx1.6+json",
+		"cyclonedx1.6+xml",
 		"spdx2.3+json",
 	}
 


### PR DESCRIPTION
Extends the list of accepted SBOM formats to include `CycloneDX 1.6`