### PR TITLE
feat: add support for --gradle-normalize-deps

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -19,6 +19,7 @@ const (
 	FlagScanAllUnmanaged             = "scan-all-unmanaged"
 	FlagSubProject                   = "sub-project"
 	FlagGradleSubProject             = "gradle-sub-project"
+	FlagGradleNormalizeDeps          = "gradle-normalize-deps"
 	FlagAllSubProjects               = "all-sub-projects"
 	FlagConfigurationMatching        = "configuration-matching"
 	FlagConfigurationAttributes      = "configuration-attributes"
@@ -54,6 +55,7 @@ func GetSBOMCreateFlagSet() *pflag.FlagSet {
 	flagSet.Bool(FlagScanAllUnmanaged, false, "Auto-detect Maven, JAR, WAR, and AAR files recursively from the current folder.")
 	flagSet.String(FlagSubProject, "", "Name of Gradle sub-project to test.")
 	flagSet.String(FlagGradleSubProject, "", "Name of Gradle sub-project to test.")
+	flagSet.Bool(FlagGradleNormalizeDeps, false, "Normalize Gradle dependencies.")
 	flagSet.Bool(FlagAllSubProjects, false, "Test all sub-projects in a multi-project build.")
 	flagSet.String(FlagNPMStrictOutOfSync, "true", "Prevent testing out-of-sync lockfiles.")
 	flagSet.Bool(FlagNugetAssetsProjectName, false,


### PR DESCRIPTION
This adds support for the `--gradle-normalize-deps` flag to get forwarded to the DepGraph workflow.