### PR TITLE
feat(monitor): monitor stubbed dep-graphs as target

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.4
 
 require (
 	github.com/bradleyjkemp/cupaloy/v2 v2.8.0
-	github.com/charmbracelet/lipgloss v0.10.0
+	github.com/charmbracelet/lipgloss v1.0.0
 	github.com/golang/mock v1.6.0
 	github.com/muesli/termenv v0.15.2
 	github.com/snyk/error-catalog-golang-public v0.0.0-20250218074309-307ad7b38a60
@@ -23,6 +23,7 @@ require (
 	github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/charmbracelet/x/ansi v0.4.2 // indirect
 	github.com/cloudflare/circl v1.6.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -61,7 +62,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
-	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1 // indirect
 	github.com/oapi-codegen/runtime v1.1.1 // indirect
 	github.com/oasdiff/yaml v0.0.0-20241214135536-5f7845c759c8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,10 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
-github.com/charmbracelet/lipgloss v0.10.0 h1:KWeXFSexGcfahHX+54URiZGkBFazf70JNMtwg/AFW3s=
-github.com/charmbracelet/lipgloss v0.10.0/go.mod h1:Wig9DSfvANsxqkRsqj6x87irdy123SR4dOXlKa91ciE=
+github.com/charmbracelet/lipgloss v1.0.0 h1:O7VkGDvqEdGi93X+DeqsQ7PKHDgtQfF8j8/O2qFMQNg=
+github.com/charmbracelet/lipgloss v1.0.0/go.mod h1:U5fy9Z+C38obMs+T+tJqst9VGzlOYGj4ri9reL3qUlo=
+github.com/charmbracelet/x/ansi v0.4.2 h1:0JM6Aj/g/KC154/gOP4vfxun0ff6itogDYk41kof+qk=
+github.com/charmbracelet/x/ansi v0.4.2/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -156,15 +158,12 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
-github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
-github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -211,7 +210,6 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/puzpuzpuz/xsync v1.5.2 h1:yRAP4wqSOZG+/4pxJ08fPTwrfL0IzE/LKQ/cw509qGY=
 github.com/puzpuzpuz/xsync v1.5.2/go.mod h1:K98BYhX3k1dQ2M63t1YNVDanbwUPmBCAhNmVrrxfiGg=
-github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/internal/commands/sbommonitor/presentation.go
+++ b/internal/commands/sbommonitor/presentation.go
@@ -9,6 +9,8 @@ import (
 	"github.com/snyk/cli-extension-sbom/internal/snykclient"
 )
 
+// TODO: move this to internal/view pkg.
+// TODO: accept an io.Writer.
 func presentSBOMMonitor(monitors []snykclient.MonitorDepsResponse) string {
 	var body = make([]string, 0)
 

--- a/internal/commands/sbommonitor/presentation.go
+++ b/internal/commands/sbommonitor/presentation.go
@@ -1,0 +1,51 @@
+package sbommonitor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/snyk/cli-extension-sbom/internal/snykclient"
+)
+
+func presentSBOMMonitor(monitors []snykclient.MonitorDepsResponse) string {
+	var body = make([]string, 0)
+
+	for i, m := range monitors {
+		if i > 0 {
+			body = append(body, renderDivider())
+		}
+
+		body = append(
+			body,
+			renderTitle(fmt.Sprintf("Monitoring '%s'...", m.ProjectName)),
+			"Explore this snapshot at "+renderLink(m.URI)+renderNewLine(),
+			"Notifications about newly disclosed issues related to these dependencies will be emailed to you.",
+		)
+	}
+
+	return strings.Join(body, "\n") + renderNewLine()
+}
+
+func renderBold(str string) string {
+	return lipgloss.NewStyle().Bold(true).Render(str)
+}
+
+func renderLink(str string) string {
+	return lipgloss.NewStyle().
+		Foreground(lipgloss.Color("12")).
+		Render(str)
+}
+
+func renderDivider() string {
+	return "\n─────────────────────────────────────────────────────"
+}
+
+func renderNewLine() string {
+	return "\n"
+}
+
+func renderTitle(str string) string {
+	return fmt.Sprintf("\n%s\n", renderBold(str))
+}

--- a/internal/commands/sbommonitor/sbommonitor.go
+++ b/internal/commands/sbommonitor/sbommonitor.go
@@ -1,13 +1,17 @@
 package sbommonitor
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
 	"github.com/snyk/cli-extension-sbom/internal/errors"
 	"github.com/snyk/cli-extension-sbom/internal/flags"
+	"github.com/snyk/cli-extension-sbom/internal/sbom"
+	"github.com/snyk/cli-extension-sbom/internal/snykclient"
 )
 
 var WorkflowID = workflow.NewWorkflowIdentifier("sbom.monitor")
@@ -32,6 +36,7 @@ func MonitorWorkflow(
 	experimental := config.GetBool(flags.FlagExperimental)
 	filename := config.GetString(flags.FlagFile)
 	errFactory := errors.NewErrorFactory(logger)
+	ctx := context.Background()
 
 	logger.Println("SBOM Monitor workflow start")
 
@@ -53,8 +58,57 @@ func MonitorWorkflow(
 
 	logger.Println("Target SBOM document:", filename)
 
-	data := "SBOM Monitor Success!"
-	return []workflow.Data{workflowData([]byte(data), "text/plain")}, nil
+	bts, err := sbom.ReadSBOMFile(filename, errFactory)
+	if err != nil {
+		return nil, err
+	}
+
+	client := snykclient.NewSnykClient(
+		ictx.GetNetworkAccess().GetHttpClient(),
+		config.GetString(configuration.API_URL),
+		orgID,
+	)
+
+	scanResults, err := client.ConvertSBOM(ctx, errFactory, bts, filename)
+	if err != nil {
+		return nil, err
+	}
+
+	monitors := make([]snykclient.MonitorDepsResponse, 0)
+	for _, sr := range scanResults {
+		monitor, err := client.MonitorDeps(ctx, errFactory, &sr)
+		if err != nil {
+			return nil, err
+		}
+
+		monitors = append(monitors, *monitor)
+	}
+
+	output := formatMonitorOutput(monitors)
+	return []workflow.Data{workflowData([]byte(output), "text/plain")}, nil
+}
+
+func formatMonitorOutput(monitors []snykclient.MonitorDepsResponse) string {
+	var sb strings.Builder
+	for _, m := range monitors {
+		if sb.Len() > 0 {
+			sb.WriteString("\n")
+			sb.WriteString("-------------------------------------------------------")
+			sb.WriteString("\n")
+		}
+
+		sb.WriteString("\n")
+		sb.WriteString("Monitoring '")
+		sb.WriteString(m.ProjectName)
+		sb.WriteString("'\n\n")
+		sb.WriteString("Explore this snapshot at ")
+		sb.WriteString(m.URI)
+		sb.WriteString("\n\n")
+		sb.WriteString("Notifications about newly disclosed issues related to these dependencies will be emailed to you.")
+		sb.WriteString("\n\n")
+	}
+
+	return sb.String()
 }
 
 func workflowData(data []byte, contentType string) workflow.Data {

--- a/internal/commands/sbommonitor/sbommonitor.go
+++ b/internal/commands/sbommonitor/sbommonitor.go
@@ -3,7 +3,6 @@ package sbommonitor
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
@@ -84,31 +83,9 @@ func MonitorWorkflow(
 		monitors = append(monitors, *monitor)
 	}
 
-	output := formatMonitorOutput(monitors)
+	output := presentSBOMMonitor(monitors)
+
 	return []workflow.Data{workflowData([]byte(output), "text/plain")}, nil
-}
-
-func formatMonitorOutput(monitors []snykclient.MonitorDepsResponse) string {
-	var sb strings.Builder
-	for _, m := range monitors {
-		if sb.Len() > 0 {
-			sb.WriteString("\n")
-			sb.WriteString("-------------------------------------------------------")
-			sb.WriteString("\n")
-		}
-
-		sb.WriteString("\n")
-		sb.WriteString("Monitoring '")
-		sb.WriteString(m.ProjectName)
-		sb.WriteString("'\n\n")
-		sb.WriteString("Explore this snapshot at ")
-		sb.WriteString(m.URI)
-		sb.WriteString("\n\n")
-		sb.WriteString("Notifications about newly disclosed issues related to these dependencies will be emailed to you.")
-		sb.WriteString("\n\n")
-	}
-
-	return sb.String()
 }
 
 func workflowData(data []byte, contentType string) workflow.Data {

--- a/internal/snykclient/monitordeps.go
+++ b/internal/snykclient/monitordeps.go
@@ -1,0 +1,54 @@
+package snykclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/snyk/cli-extension-sbom/internal/errors"
+)
+
+const ContentTypeHeader = "Content-Type"
+const MIMETypeJSON = "application/json"
+
+func (t *SnykClient) MonitorDeps(
+	ctx context.Context,
+	errFactory *errors.ErrorFactory,
+	scanResult *ScanResult,
+) (*MonitorDepsResponse, error) {
+	url := fmt.Sprintf("%s/v1/monitor-dependencies", t.apiBaseURL)
+
+	scanResultReq := ScanResultRequest{ScanResult: *scanResult}
+	scanResultJSON, err := json.Marshal(scanResultReq)
+	if err != nil {
+		return nil, errFactory.NewFatalSBOMMonitorError(err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(scanResultJSON))
+	if err != nil {
+		return nil, errFactory.NewFatalSBOMMonitorError(err)
+	}
+	req.Header.Set(ContentTypeHeader, MIMETypeJSON)
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, errFactory.NewFatalSBOMMonitorError(err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errFactory.NewFatalSBOMMonitorError(err)
+	}
+
+	var depsResp MonitorDepsResponse
+	err = json.Unmarshal(bodyBytes, &depsResp)
+	if err != nil {
+		return nil, errFactory.NewFatalSBOMMonitorError(err)
+	}
+
+	return &depsResp, nil
+}

--- a/internal/snykclient/monitordeps_test.go
+++ b/internal/snykclient/monitordeps_test.go
@@ -1,0 +1,45 @@
+package snykclient_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/cli-extension-sbom/internal/mocks"
+	"github.com/snyk/cli-extension-sbom/internal/snykclient"
+)
+
+var exampleScanResult = snykclient.ScanResult{
+	Name:   "Bob",
+	Policy: "",
+	Facts: []snykclient.ScanResultFact{
+		{Type: "depgraph", Data: ""},
+	},
+	Target:          snykclient.ScanResultTarget{Name: "myTarget"},
+	Identity:        snykclient.ScanResultIdentity{Type: "npm"},
+	TargetReference: "",
+}
+
+func Test_MonitorDeps(t *testing.T) {
+	response := mocks.NewMockResponse(
+		"application/json; charset=utf-8",
+		[]byte(`{"ok":true,"uri":"https://example.com/","isMonitored":true,"projectName":"myProject"}`),
+		http.StatusOK,
+	)
+
+	mockHTTPClient := mocks.NewMockSBOMService(response, func(r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/v1/monitor-dependencies", r.RequestURI)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+	})
+
+	client := snykclient.NewSnykClient(mockHTTPClient.Client(), mockHTTPClient.URL, "org1")
+	depsResp, err := client.MonitorDeps(context.Background(), errFactory, &exampleScanResult)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.com/", depsResp.URI)
+	assert.Equal(t, "myProject", depsResp.ProjectName)
+	assert.True(t, depsResp.IsMonitored)
+}

--- a/internal/snykclient/monitordeps_test.go
+++ b/internal/snykclient/monitordeps_test.go
@@ -31,7 +31,7 @@ func Test_MonitorDeps(t *testing.T) {
 
 	mockHTTPClient := mocks.NewMockSBOMService(response, func(r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
-		assert.Equal(t, "/v1/monitor-dependencies", r.RequestURI)
+		assert.Equal(t, "/v1/monitor-dependencies?org=org1", r.RequestURI)
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 	})
 

--- a/internal/snykclient/sbomconverter.go
+++ b/internal/snykclient/sbomconverter.go
@@ -4,6 +4,7 @@ package snykclient
 import (
 	"context"
 	"encoding/json"
+	"io"
 
 	"github.com/snyk/cli-extension-sbom/internal/errors"
 )
@@ -52,7 +53,7 @@ const pipProjectJSON = `
 func (t *SnykClient) ConvertSBOM(
 	ctx context.Context,
 	errFactory *errors.ErrorFactory,
-	sbomBytes []byte,
+	sbom io.Reader,
 	filename string,
 ) ([]ScanResult, error) {
 	var pubProject ScanResult

--- a/internal/snykclient/sbomconverter.go
+++ b/internal/snykclient/sbomconverter.go
@@ -1,0 +1,58 @@
+//nolint:lll // Long lined example dep-graphs will be removed in the future.
+package snykclient
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/snyk/cli-extension-sbom/internal/errors"
+)
+
+const targetName = "SBOM Monitor Spike v2"
+
+const pubProjectJSON = `
+{
+	"name": "Dart project",
+	"policy": "\n",
+	"facts": [{
+		"type": "depGraph",
+		"data": {"schemaVersion":"1.2.0","pkgManager":{"name":"pub"},"pkgs":[{"id":"my-project@0.0.0","info":{"name":"my-project","version":"0.0.0"}},{"id":"pubnub@1.0.0","info":{"name":"pubnub","version":"1.0.0"}}],"graph":{"rootNodeId":"root-node","nodes":[{"nodeId":"root-node","pkgId":"my-project@0.0.0","deps":[{"nodeId":"pubnub@1.0.0"}]},{"nodeId":"pubnub@1.0.0","pkgId":"pubnub@1.0.0","deps":[]}]}}
+	}],
+	"target": { "name": "` + targetName + `" },
+	"identity": { "type": "pub" }
+}
+`
+
+const npmProjectJSON = `
+{
+	"name": "simple npm vuln project",
+	"policy": "\n",
+	"facts": [{
+		"type": "depGraph",
+		"data": {"schemaVersion":"1.3.0","pkgManager":{"name":"npm"},"pkgs":[{"id":"my-great-project@1.0.0","info":{"name":"my-great-project","version":"1.0.0","purl":"pkg:npm/my-great-project@1.0.0"}},{"id":"minimatch@3.0.4","info":{"name":"minimatch","version":"3.0.4","purl":"pkg:npm/minimatch@3.0.4"}},{"id":"brace-expansion@1.1.11","info":{"name":"brace-expansion","version":"1.1.11","purl":"pkg:npm/brace-expansion@1.1.11"}},{"id":"balanced-match@1.0.2","info":{"name":"balanced-match","version":"1.0.2","purl":"pkg:npm/balanced-match@1.0.2"}},{"id":"concat-map@0.0.1","info":{"name":"concat-map","version":"0.0.1","purl":"pkg:npm/concat-map@0.0.1"}}],"graph":{"rootNodeId":"root-node","nodes":[{"nodeId":"concat-map@0.0.1","pkgId":"concat-map@0.0.1","deps":[]},{"nodeId":"root-node","pkgId":"my-great-project@1.0.0","deps":[{"nodeId":"minimatch@3.0.4"}]},{"nodeId":"minimatch@3.0.4","pkgId":"minimatch@3.0.4","deps":[{"nodeId":"brace-expansion@1.1.11"}]},{"nodeId":"brace-expansion@1.1.11","pkgId":"brace-expansion@1.1.11","deps":[{"nodeId":"balanced-match@1.0.2"},{"nodeId":"concat-map@0.0.1"}]},{"nodeId":"balanced-match@1.0.2","pkgId":"balanced-match@1.0.2","deps":[]}]}}
+	}],
+	"target": { "name": "` + targetName + `" },
+	"identity": { "type": "npm" }
+}
+`
+
+func (t *SnykClient) ConvertSBOM(
+	ctx context.Context,
+	errFactory *errors.ErrorFactory,
+	sbomBytes []byte,
+	filename string,
+) ([]ScanResult, error) {
+	var pubProject ScanResult
+	err := json.Unmarshal([]byte(pubProjectJSON), &pubProject)
+	if err != nil {
+		return nil, err
+	}
+
+	var npmProject ScanResult
+	err = json.Unmarshal([]byte(npmProjectJSON), &npmProject)
+	if err != nil {
+		return nil, err
+	}
+
+	return []ScanResult{pubProject, npmProject}, nil
+}

--- a/internal/snykclient/sbomconverter.go
+++ b/internal/snykclient/sbomconverter.go
@@ -36,6 +36,19 @@ const npmProjectJSON = `
 }
 `
 
+const pipProjectJSON = `
+{
+	"name": "simple pip project",
+	"policy": "\n",
+	"facts": [{
+		"type": "depGraph",
+		"data": {"schemaVersion":"1.3.0","pkgManager":{"name":"pip"},"pkgs":[{"id":"certifi@2024.12.14","info":{"name":"certifi","version":"2024.12.14","purl":"pkg:pypi/certifi@2024.12.14"}},{"id":"charset-normalizer@3.4.1","info":{"name":"charset-normalizer","version":"3.4.1","purl":"pkg:pypi/charset-normalizer@3.4.1"}},{"id":"idna@3.10","info":{"name":"idna","version":"3.10","purl":"pkg:pypi/idna@3.10"}},{"id":"urllib3@2.3.0","info":{"name":"urllib3","version":"2.3.0","purl":"pkg:pypi/urllib3@2.3.0"}},{"id":"pip-project-sbom-monitor-test@0.0.0","info":{"name":"pip-project-sbom-monitor-test","version":"0.0.0","purl":"pkg:pypi/pip-project-sbom-monitor-test@0.0.0"}},{"id":"requests@2.32.3","info":{"name":"requests","version":"2.32.3","purl":"pkg:pypi/requests@2.32.3"}}],"graph":{"rootNodeId":"root-node","nodes":[{"nodeId":"idna@3.10","pkgId":"idna@3.10","deps":[]},{"nodeId":"urllib3@2.3.0","pkgId":"urllib3@2.3.0","deps":[]},{"nodeId":"root-node","pkgId":"pip-project-sbom-monitor-test@0.0.0","deps":[{"nodeId":"requests@2.32.3"}]},{"nodeId":"requests@2.32.3","pkgId":"requests@2.32.3","deps":[{"nodeId":"certifi@2024.12.14"},{"nodeId":"charset-normalizer@3.4.1"},{"nodeId":"idna@3.10"},{"nodeId":"urllib3@2.3.0"}]},{"nodeId":"certifi@2024.12.14","pkgId":"certifi@2024.12.14","deps":[]},{"nodeId":"charset-normalizer@3.4.1","pkgId":"charset-normalizer@3.4.1","deps":[]}]}}
+	}],
+	"target": { "name": "` + targetName + `" },
+	"identity": { "type": "pip" }
+}
+`
+
 func (t *SnykClient) ConvertSBOM(
 	ctx context.Context,
 	errFactory *errors.ErrorFactory,
@@ -54,5 +67,11 @@ func (t *SnykClient) ConvertSBOM(
 		return nil, err
 	}
 
-	return []ScanResult{pubProject, npmProject}, nil
+	var pipProject ScanResult
+	err = json.Unmarshal([]byte(pipProjectJSON), &pipProject)
+	if err != nil {
+		return nil, err
+	}
+
+	return []ScanResult{pubProject, npmProject, pipProject}, nil
 }

--- a/internal/snykclient/types.go
+++ b/internal/snykclient/types.go
@@ -437,3 +437,41 @@ type UpdateSBOMMonitorResponseData struct {
 	ID         string                `json:"id"`
 	Type       string                `json:"type"`
 }
+
+// region: Monitor Deps
+
+type ScanResultTarget struct {
+	Name string `json:"name"`
+}
+
+type ScanResultIdentity struct {
+	Type string `json:"type"`
+}
+
+type ScanResultFact struct {
+	Type string      `json:"type"`
+	Data interface{} `json:"data"`
+}
+
+type ScanResult struct {
+	Name            string             `json:"name"`
+	Policy          string             `json:"policy,omitempty"`
+	Facts           []ScanResultFact   `json:"facts"`
+	Target          ScanResultTarget   `json:"target"`
+	Identity        ScanResultIdentity `json:"identity"`
+	TargetReference string             `json:"targetReference,omitempty"`
+}
+
+type ScanResultRequest struct {
+	ScanResult ScanResult `json:"scanResult"`
+}
+
+type MonitorDepsResponse struct {
+	OK             bool        `json:"ok"`
+	Org            string      `json:"org"`
+	ID             string      `json:"id"`
+	IsMonitored    bool        `json:"isMonitored"`
+	LicensesPolicy interface{} `json:"licensesPolicy"`
+	URI            string      `json:"uri"`
+	ProjectName    string      `json:"projectName"`
+}


### PR DESCRIPTION
### What this does?

- Adds types for `ScanResult` for submitting to monitor dependencies.
- Adds type for the monitor dependencies response.
- Adds a stub client which returns three `ScanResults` for a Python, Dart and NPM project.
- Adds a client function to submit a `ScanResult` to monitor.
- Outputs details on the monitored projects along with links to the user.

https://snyksec.atlassian.net/browse/UNIFY-531
https://snyksec.atlassian.net/browse/UNIFY-532