### PR TITLE
feat: Submit scan results to registry

### DIFF
--- a/internal/snykclient/monitordeps.go
+++ b/internal/snykclient/monitordeps.go
@@ -51,6 +51,10 @@ func (t *SnykClient) MonitorDeps(
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)

--- a/internal/snykclient/monitordeps.go
+++ b/internal/snykclient/monitordeps.go
@@ -1,0 +1,66 @@
+package snykclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/snyk/cli-extension-sbom/internal/errors"
+)
+
+const ContentTypeHeader = "Content-Type"
+const MIMETypeJSON = "application/json"
+
+func (t *SnykClient) MonitorDeps(
+	ctx context.Context,
+	errFactory *errors.ErrorFactory,
+	scanResult *ScanResult,
+) (*MonitorDepsResponse, error) {
+	u, err := url.Parse(t.apiBaseURL + "/v1/monitor-dependencies")
+	if err != nil {
+		return nil, fmt.Errorf("monitor deps api url invalid: %w", err)
+	}
+	if t.orgID != "" {
+		v := url.Values{"org": {t.orgID}}
+		u.RawQuery = v.Encode()
+	}
+
+	scanResultReq := ScanResultRequest{ScanResult: *scanResult}
+	scanResultJSON, err := json.Marshal(scanResultReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create scan result request JSON: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodPut,
+		u.String(),
+		bytes.NewReader(scanResultJSON))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set(ContentTypeHeader, MIMETypeJSON)
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var depsResp MonitorDepsResponse
+	err = json.Unmarshal(bodyBytes, &depsResp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON response: %w", err)
+	}
+
+	return &depsResp, nil
+}

--- a/internal/snykclient/monitordeps_test.go
+++ b/internal/snykclient/monitordeps_test.go
@@ -1,0 +1,45 @@
+package snykclient_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/cli-extension-sbom/internal/mocks"
+	"github.com/snyk/cli-extension-sbom/internal/snykclient"
+)
+
+var exampleScanResult = snykclient.ScanResult{
+	Name:   "Bob",
+	Policy: "",
+	Facts: []snykclient.ScanResultFact{
+		{Type: "depGraph", Data: struct{}{}},
+	},
+	Target:          snykclient.ScanResultTarget{Name: "myTarget"},
+	Identity:        snykclient.ScanResultIdentity{Type: "npm"},
+	TargetReference: "",
+}
+
+func Test_MonitorDeps(t *testing.T) {
+	response := mocks.NewMockResponse(
+		"application/json; charset=utf-8",
+		[]byte(`{"ok":true,"uri":"https://example.com/","isMonitored":true,"projectName":"myProject"}`),
+		http.StatusOK,
+	)
+
+	mockHTTPClient := mocks.NewMockSBOMService(response, func(r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/v1/monitor-dependencies?org=org1", r.RequestURI)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+	})
+
+	client := snykclient.NewSnykClient(mockHTTPClient.Client(), mockHTTPClient.URL, "org1")
+	depsResp, err := client.MonitorDeps(context.Background(), errFactory, &exampleScanResult)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.com/", depsResp.URI)
+	assert.Equal(t, "myProject", depsResp.ProjectName)
+	assert.True(t, depsResp.IsMonitored)
+}

--- a/internal/snykclient/types.go
+++ b/internal/snykclient/types.go
@@ -345,3 +345,43 @@ func (doc *SBOMTestResultResourceDocument) AsResult() *SBOMTestResult {
 
 	return &r
 }
+
+// region: Monitor Deps
+
+type ScanResultTarget struct {
+	Name string `json:"name"`
+}
+
+type ScanResultIdentity struct {
+	Type       string            `json:"type"`
+	TargetFile string            `json:"targetFile,omitempty"`
+	Args       map[string]string `json:"args,omitempty"`
+}
+
+type ScanResultFact struct {
+	Type string      `json:"type"`
+	Data interface{} `json:"data"`
+}
+
+type ScanResult struct {
+	Name            string             `json:"name"`
+	Policy          string             `json:"policy,omitempty"`
+	Facts           []ScanResultFact   `json:"facts"`
+	Target          ScanResultTarget   `json:"target"`
+	Identity        ScanResultIdentity `json:"identity"`
+	TargetReference string             `json:"targetReference,omitempty"`
+}
+
+type ScanResultRequest struct {
+	ScanResult ScanResult `json:"scanResult"`
+}
+
+type MonitorDepsResponse struct {
+	OK             bool        `json:"ok"`
+	Org            string      `json:"org"`
+	ID             string      `json:"id"`
+	IsMonitored    bool        `json:"isMonitored"`
+	LicensesPolicy interface{} `json:"licensesPolicy"`
+	URI            string      `json:"uri"`
+	ProjectName    string      `json:"projectName"`
+}


### PR DESCRIPTION
Client function to send `ScanResult` to monitor dependencies endpoint.