### PR TITLE
feat: render the output similar to a std monitor

### DIFF
--- a/internal/view/sbommonitor/init_test.go
+++ b/internal/view/sbommonitor/init_test.go
@@ -1,0 +1,13 @@
+package sbommonitor
+
+import (
+	"github.com/bradleyjkemp/cupaloy/v2"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+var snapshotter = cupaloy.New(cupaloy.SnapshotSubdirectory("testdata/snapshots"))
+
+func init() {
+	lipgloss.SetColorProfile(termenv.TrueColor)
+}

--- a/internal/view/sbommonitor/monitor.go
+++ b/internal/view/sbommonitor/monitor.go
@@ -1,0 +1,57 @@
+package sbommonitor
+
+import (
+	"bytes"
+	"html/template"
+)
+
+type monitorComponent struct {
+	monitorProjects []monitorProjectComponent
+
+	str string
+}
+
+func generateMonitorComponent(monitorProjects []monitorProjectComponent) (monitorComponent, error) {
+	m := monitorComponent{monitorProjects: monitorProjects}
+
+	if err := m.computeString(); err != nil {
+		return m, err
+	}
+
+	return m, nil
+}
+
+func (m *monitorComponent) computeString() error {
+	var buff bytes.Buffer
+
+	var projects = make([]string, len(m.monitorProjects))
+	for i, mp := range m.monitorProjects {
+		projects[i] = mp.String()
+	}
+
+	err := monitorTemplate.Execute(&buff, struct {
+		Projects []string
+	}{
+		Projects: projects,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	m.str = buff.String()
+	return nil
+}
+
+func (m *monitorComponent) String() string {
+	return m.str
+}
+
+var monitorTemplate *template.Template = template.Must(
+	template.New("sbomMonitor").
+		Parse(`{{- range $i, $project := .Projects}}
+{{- if gt $i 0}}
+─────────────────────────────────────────────────────
+{{end}}
+{{$project}}
+{{end}}`))

--- a/internal/view/sbommonitor/monitor_test.go
+++ b/internal/view/sbommonitor/monitor_test.go
@@ -1,0 +1,36 @@
+package sbommonitor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_generateMonitor_oneProject(t *testing.T) {
+	proj1, err := generateMonitorProjectComponent("Bob", "https://example.com/bob")
+	require.NoError(t, err)
+	projects := []monitorProjectComponent{proj1}
+
+	monitor, err := generateMonitorComponent(projects)
+
+	assert.NoError(t, err)
+
+	snapshotter.SnapshotT(t, monitor.String())
+}
+
+func Test_generateMonitor_multipleProjects(t *testing.T) {
+	proj1, err := generateMonitorProjectComponent("Bob", "https://example.com/bob")
+	require.NoError(t, err)
+
+	proj2, err := generateMonitorProjectComponent("Alice", "https://example.com/alice")
+	require.NoError(t, err)
+
+	projects := []monitorProjectComponent{proj1, proj2}
+
+	monitor, err := generateMonitorComponent(projects)
+
+	assert.NoError(t, err)
+
+	snapshotter.SnapshotT(t, monitor.String())
+}

--- a/internal/view/sbommonitor/project.go
+++ b/internal/view/sbommonitor/project.go
@@ -1,0 +1,61 @@
+package sbommonitor
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+)
+
+type monitorProjectComponent struct {
+	projectName string
+	uri         string
+
+	str string
+}
+
+func generateMonitorProjectComponent(projectName, uri string) (monitorProjectComponent, error) {
+	mp := monitorProjectComponent{
+		projectName: projectName,
+		uri:         uri,
+	}
+
+	if err := mp.computeString(); err != nil {
+		return mp, err
+	}
+
+	return mp, nil
+}
+
+func (m *monitorProjectComponent) getTitle() string {
+	return fmt.Sprintf("Monitoring '%s'...", m.projectName)
+}
+
+func (m *monitorProjectComponent) computeString() error {
+	var buff bytes.Buffer
+
+	err := monitorProjectDetailsTemplate.Execute(&buff, struct {
+		Title string
+		URI   string
+	}{
+		Title: bold.Render(m.getTitle()),
+		URI:   m.uri,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	m.str = buff.String()
+	return nil
+}
+
+func (m *monitorProjectComponent) String() string {
+	return m.str
+}
+
+var monitorProjectDetailsTemplate *template.Template = template.Must(
+	template.New("sbomMonitorProject").Parse(`{{.Title}}
+
+Explore this snapshot at {{.URI}}
+
+Notifications about newly disclosed issues related to these dependencies will be emailed to you.`))

--- a/internal/view/sbommonitor/project_test.go
+++ b/internal/view/sbommonitor/project_test.go
@@ -1,0 +1,18 @@
+package sbommonitor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_generateMonitorProject(t *testing.T) {
+	project, err := generateMonitorProjectComponent(
+		"My project",
+		"https://example.com/my-project",
+	)
+
+	assert.NoError(t, err)
+
+	snapshotter.SnapshotT(t, project.String())
+}

--- a/internal/view/sbommonitor/render.go
+++ b/internal/view/sbommonitor/render.go
@@ -1,0 +1,26 @@
+package sbommonitor
+
+import (
+	"io"
+
+	"github.com/snyk/cli-extension-sbom/internal/snykclient"
+)
+
+func RenderMonitor(dst io.Writer, monitors []*snykclient.MonitorDependenciesResponse) (int, error) {
+	var mp = make([]monitorProjectComponent, len(monitors))
+
+	for i, m := range monitors {
+		c, err := generateMonitorProjectComponent(m.ProjectName, m.URI)
+		if err != nil {
+			return 0, err
+		}
+		mp[i] = c
+	}
+
+	monitor, err := generateMonitorComponent(mp)
+	if err != nil {
+		return 0, err
+	}
+
+	return io.WriteString(dst, monitor.String())
+}

--- a/internal/view/sbommonitor/render_test.go
+++ b/internal/view/sbommonitor/render_test.go
@@ -1,0 +1,48 @@
+package sbommonitor
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-sbom/internal/snykclient"
+)
+
+func TestRenderMonitor(t *testing.T) {
+	monitors := []*snykclient.MonitorDependenciesResponse{
+		{ProjectName: "Test Project", URI: "https://example.com/test_project"},
+	}
+
+	var buf bytes.Buffer
+	_, err := RenderMonitor(&buf, monitors)
+	require.NoError(t, err)
+
+	output := buf.String()
+
+	assert.Contains(t, output, monitors[0].ProjectName, "Output should contain the project name")
+	assert.Contains(t, output, monitors[0].URI, "Output should contain the URI")
+
+	snapshotter.SnapshotT(t, output)
+}
+
+func TestRenderMonitor_MultipleProjects(t *testing.T) {
+	monitors := []*snykclient.MonitorDependenciesResponse{
+		{ProjectName: "Test Project", URI: "https://example.com/test_project"},
+		{ProjectName: "A Different Project", URI: "https://example.com/different_project"},
+	}
+
+	var buf bytes.Buffer
+	_, err := RenderMonitor(&buf, monitors)
+	require.NoError(t, err)
+
+	output := buf.String()
+
+	for _, m := range monitors {
+		assert.Contains(t, output, m.ProjectName, "Output should contain the project name")
+		assert.Contains(t, output, m.URI, "Output should contain the URI")
+	}
+
+	snapshotter.SnapshotT(t, output)
+}

--- a/internal/view/sbommonitor/style.go
+++ b/internal/view/sbommonitor/style.go
@@ -1,0 +1,5 @@
+package sbommonitor
+
+import "github.com/charmbracelet/lipgloss"
+
+var bold = lipgloss.NewStyle().Bold(true)

--- a/internal/view/sbommonitor/testdata/snapshots/TestRenderMonitor
+++ b/internal/view/sbommonitor/testdata/snapshots/TestRenderMonitor
@@ -1,0 +1,7 @@
+
+[1mMonitoring &#39;Test Project&#39;...[0m
+
+Explore this snapshot at https://example.com/test_project
+
+Notifications about newly disclosed issues related to these dependencies will be emailed to you.
+

--- a/internal/view/sbommonitor/testdata/snapshots/TestRenderMonitor_MultipleProjects
+++ b/internal/view/sbommonitor/testdata/snapshots/TestRenderMonitor_MultipleProjects
@@ -1,0 +1,15 @@
+
+[1mMonitoring &#39;Test Project&#39;...[0m
+
+Explore this snapshot at https://example.com/test_project
+
+Notifications about newly disclosed issues related to these dependencies will be emailed to you.
+
+─────────────────────────────────────────────────────
+
+[1mMonitoring &#39;A Different Project&#39;...[0m
+
+Explore this snapshot at https://example.com/different_project
+
+Notifications about newly disclosed issues related to these dependencies will be emailed to you.
+

--- a/internal/view/sbommonitor/testdata/snapshots/Test_generateMonitorProject
+++ b/internal/view/sbommonitor/testdata/snapshots/Test_generateMonitorProject
@@ -1,0 +1,5 @@
+[1mMonitoring 'My project'...[0m
+
+Explore this snapshot at https://example.com/my-project
+
+Notifications about newly disclosed issues related to these dependencies will be emailed to you.

--- a/internal/view/sbommonitor/testdata/snapshots/Test_generateMonitor_multipleProjects
+++ b/internal/view/sbommonitor/testdata/snapshots/Test_generateMonitor_multipleProjects
@@ -1,0 +1,15 @@
+
+[1mMonitoring &#39;Bob&#39;...[0m
+
+Explore this snapshot at https://example.com/bob
+
+Notifications about newly disclosed issues related to these dependencies will be emailed to you.
+
+─────────────────────────────────────────────────────
+
+[1mMonitoring &#39;Alice&#39;...[0m
+
+Explore this snapshot at https://example.com/alice
+
+Notifications about newly disclosed issues related to these dependencies will be emailed to you.
+

--- a/internal/view/sbommonitor/testdata/snapshots/Test_generateMonitor_oneProject
+++ b/internal/view/sbommonitor/testdata/snapshots/Test_generateMonitor_oneProject
@@ -1,0 +1,7 @@
+
+[1mMonitoring &#39;Bob&#39;...[0m
+
+Explore this snapshot at https://example.com/bob
+
+Notifications about newly disclosed issues related to these dependencies will be emailed to you.
+


### PR DESCRIPTION
Show the cli user what projects have been monitored and where to find them.

- Output is in the same style as the existing `snyk monitor` command.
- The tests assert key information is present while ignoring presentation style.