### PR TITLE
feat: convert SBOM into scan results

### DIFF
--- a/internal/snykclient/monitordeps.go
+++ b/internal/snykclient/monitordeps.go
@@ -52,7 +52,7 @@ func (t *SnykClient) MonitorDeps(
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode) //nolint:goconst // ok to repeat error message.
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)

--- a/internal/snykclient/monitordeps.go
+++ b/internal/snykclient/monitordeps.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 
@@ -55,13 +54,8 @@ func (t *SnykClient) MonitorDeps(
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode) //nolint:goconst // ok to repeat error message.
 	}
 
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
 	var depsResp MonitorDepsResponse
-	err = json.Unmarshal(bodyBytes, &depsResp)
+	err = json.NewDecoder(resp.Body).Decode(&depsResp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal JSON response: %w", err)
 	}

--- a/internal/snykclient/sbomconvert.go
+++ b/internal/snykclient/sbomconvert.go
@@ -1,0 +1,72 @@
+package snykclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/snyk/cli-extension-sbom/internal/errors"
+)
+
+const (
+	sbomConvertAPIVersion = "2025-03-06~beta"
+	MIMETypeOctetStream   = "application/octet-stream"
+)
+
+func (t *SnykClient) SBOMConvert(
+	ctx context.Context,
+	errFactory *errors.ErrorFactory,
+	sbom io.Reader,
+) ([]ScanResult, error) {
+	u, err := buildSBOMConvertAPIURL(t.apiBaseURL, sbomConvertAPIVersion, t.orgID)
+	if err != nil {
+		return nil, fmt.Errorf("sbom convert api url invalid: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		u.String(),
+		sbom,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set(ContentTypeHeader, MIMETypeOctetStream)
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var convertResp SBOMConvertResponse
+	err = json.NewDecoder(resp.Body).Decode(&convertResp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON response: %w", err)
+	}
+
+	return convertResp.ScanResults, nil
+}
+
+func buildSBOMConvertAPIURL(apiBaseURL, apiVersion, orgID string) (*url.URL, error) {
+	u, err := url.Parse(apiBaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	u = u.JoinPath("hidden", "orgs", orgID, "sboms", "convert")
+
+	query := url.Values{"version": {apiVersion}}
+	u.RawQuery = query.Encode()
+
+	return u, nil
+}

--- a/internal/snykclient/sbomconvert_test.go
+++ b/internal/snykclient/sbomconvert_test.go
@@ -1,0 +1,112 @@
+package snykclient_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/cli-extension-sbom/internal/mocks"
+	"github.com/snyk/cli-extension-sbom/internal/snykclient"
+)
+
+func Test_SBOMConvert(t *testing.T) {
+	response := mocks.NewMockResponse(
+		"application/json; charset=utf-8",
+		[]byte(`{"scanResults":[{"name":"Scan 1"},{"name":"Scan 2"}]}`),
+		http.StatusOK,
+	)
+
+	sbomContent := `{"foo":"bar"}`
+
+	mockHTTPClient := mocks.NewMockSBOMService(response, func(r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/hidden/orgs/org1/sboms/convert?version=2025-03-06~beta", r.RequestURI)
+		assert.Equal(t, "application/octet-stream", r.Header.Get("Content-Type"))
+	})
+
+	client := snykclient.NewSnykClient(mockHTTPClient.Client(), mockHTTPClient.URL, "org1")
+	depsResp, err := client.SBOMConvert(
+		context.Background(),
+		errFactory,
+		bytes.NewBuffer([]byte(sbomContent)),
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(depsResp))
+	assert.Equal(t, "Scan 1", depsResp[0].Name)
+	assert.Equal(t, "Scan 2", depsResp[1].Name)
+}
+
+func Test_SBOMConvert_InvalidJSONReturned(t *testing.T) {
+	response := mocks.NewMockResponse(
+		"application/json; charset=utf-8",
+		[]byte(`{"scanResults":[{"name":"Scan 1"`),
+		http.StatusOK,
+	)
+
+	sbomContent := `{"foo":"bar"}`
+
+	mockHTTPClient := mocks.NewMockSBOMService(response)
+
+	client := snykclient.NewSnykClient(mockHTTPClient.Client(), mockHTTPClient.URL, "org1")
+	_, err := client.SBOMConvert(
+		context.Background(),
+		errFactory,
+		bytes.NewBuffer([]byte(sbomContent)),
+	)
+
+	assert.ErrorContains(t, err, "failed to unmarshal JSON response")
+}
+
+func Test_SBOMConvert_ServerErrors(t *testing.T) {
+	testCases := []struct {
+		name         string
+		statusCode   int
+		responseBody string
+	}{
+		{
+			name:         "Forbidden (403) - Feature not available",
+			statusCode:   http.StatusForbidden,
+			responseBody: `{"message":"This functionality is not available on your plan."}`,
+		},
+		{
+			name:         "Bad Request (400) - Malformed Request",
+			statusCode:   http.StatusBadRequest,
+			responseBody: "",
+		},
+		{
+			name:         "Internal Server Error (500) - Server Issue",
+			statusCode:   http.StatusInternalServerError,
+			responseBody: `{"message":"Internal server error."}`,
+		},
+	}
+
+	sbomContent := `{"foo":"bar"}`
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			response := mocks.NewMockResponse(
+				"application/json; charset=utf-8",
+				[]byte(tc.responseBody),
+				tc.statusCode,
+			)
+
+			mockHTTPClient := mocks.NewMockSBOMService(response)
+
+			client := snykclient.NewSnykClient(mockHTTPClient.Client(), mockHTTPClient.URL, "org1")
+			_, err := client.SBOMConvert(context.Background(), errFactory, bytes.NewBufferString(sbomContent))
+
+			assert.ErrorContainsf(
+				t,
+				err,
+				fmt.Sprintf("%d", tc.statusCode),
+				"Expected error to contain status code %d",
+				tc.statusCode,
+			)
+		})
+	}
+}

--- a/internal/snykclient/types.go
+++ b/internal/snykclient/types.go
@@ -376,6 +376,10 @@ type ScanResultRequest struct {
 	ScanResult ScanResult `json:"scanResult"`
 }
 
+type SBOMConvertResponse struct {
+	ScanResults []ScanResult `json:"scanResults"`
+}
+
 type MonitorDepsResponse struct {
 	OK             bool        `json:"ok"`
 	Org            string      `json:"org"`


### PR DESCRIPTION
A client to convert an SBOM into an array of `ScanResult`s.