### PR TITLE
feat: add methods to augment ScanResult

### DIFF
--- a/internal/snykclient/monitordeps.go
+++ b/internal/snykclient/monitordeps.go
@@ -14,11 +14,11 @@ import (
 const ContentTypeHeader = "Content-Type"
 const MIMETypeJSON = "application/json"
 
-func (t *SnykClient) MonitorDeps(
+func (t *SnykClient) MonitorDependencies(
 	ctx context.Context,
 	errFactory *errors.ErrorFactory,
 	scanResult *ScanResult,
-) (*MonitorDepsResponse, error) {
+) (*MonitorDependenciesResponse, error) {
 	u, err := url.Parse(t.apiBaseURL + "/v1/monitor-dependencies")
 	if err != nil {
 		return nil, fmt.Errorf("monitor deps api url invalid: %w", err)
@@ -54,11 +54,32 @@ func (t *SnykClient) MonitorDeps(
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode) //nolint:goconst // ok to repeat error message.
 	}
 
-	var depsResp MonitorDepsResponse
+	var depsResp MonitorDependenciesResponse
 	err = json.NewDecoder(resp.Body).Decode(&depsResp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal JSON response: %w", err)
 	}
 
 	return &depsResp, nil
+}
+
+func (r *ScanResult) WithSnykPolicy(plc []byte) *ScanResult {
+	if len(plc) > 0 {
+		r.Policy = string(plc)
+	}
+	return r
+}
+
+func (r *ScanResult) WithTargetName(n string) *ScanResult {
+	if n != "" {
+		r.Target.Name = n
+	}
+	return r
+}
+
+func (r *ScanResult) WithTargetReference(ref string) *ScanResult {
+	if ref != "" {
+		r.TargetReference = ref
+	}
+	return r
 }

--- a/internal/snykclient/monitordeps_test.go
+++ b/internal/snykclient/monitordeps_test.go
@@ -15,7 +15,7 @@ import (
 var exampleScanResult = snykclient.ScanResult{
 	Name:   "Bob",
 	Policy: "",
-	Facts: []snykclient.ScanResultFact{
+	Facts: []*snykclient.ScanResultFact{
 		{Type: "depGraph", Data: struct{}{}},
 	},
 	Target:          snykclient.ScanResultTarget{Name: "myTarget"},
@@ -23,7 +23,7 @@ var exampleScanResult = snykclient.ScanResult{
 	TargetReference: "",
 }
 
-func Test_MonitorDeps(t *testing.T) {
+func Test_MonitorDependencies(t *testing.T) {
 	response := mocks.NewMockResponse(
 		"application/json; charset=utf-8",
 		[]byte(`{"ok":true,"uri":"https://example.com/","isMonitored":true,"projectName":"myProject"}`),
@@ -37,7 +37,7 @@ func Test_MonitorDeps(t *testing.T) {
 	})
 
 	client := snykclient.NewSnykClient(mockHTTPClient.Client(), mockHTTPClient.URL, "org1")
-	depsResp, err := client.MonitorDeps(context.Background(), errFactory, &exampleScanResult)
+	depsResp, err := client.MonitorDependencies(context.Background(), errFactory, &exampleScanResult)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "https://example.com/", depsResp.URI)
@@ -79,7 +79,7 @@ func Test_MonitorDeps_ServerErrors(t *testing.T) {
 			mockHTTPClient := mocks.NewMockSBOMService(response)
 
 			client := snykclient.NewSnykClient(mockHTTPClient.Client(), mockHTTPClient.URL, "org1")
-			_, err := client.MonitorDeps(context.Background(), errFactory, &exampleScanResult)
+			_, err := client.MonitorDependencies(context.Background(), errFactory, &exampleScanResult)
 
 			assert.ErrorContainsf(
 				t,
@@ -89,4 +89,28 @@ func Test_MonitorDeps_ServerErrors(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestScanResult_WithSnykPolicy(t *testing.T) {
+	r := snykclient.ScanResult{}
+
+	r.WithSnykPolicy([]byte("ignore: {}\n"))
+
+	assert.Equal(t, "ignore: {}\n", r.Policy)
+}
+
+func TestScanResult_WithTargetName(t *testing.T) {
+	r := snykclient.ScanResult{}
+
+	r.WithTargetName("my-sbom-target")
+
+	assert.Equal(t, "my-sbom-target", r.Target.Name)
+}
+
+func TestScanResult_WithTargetReference(t *testing.T) {
+	r := snykclient.ScanResult{}
+
+	r.WithTargetReference("main")
+
+	assert.Equal(t, "main", r.TargetReference)
 }

--- a/internal/snykclient/sbomconvert.go
+++ b/internal/snykclient/sbomconvert.go
@@ -20,7 +20,7 @@ func (t *SnykClient) SBOMConvert(
 	ctx context.Context,
 	errFactory *errors.ErrorFactory,
 	sbom io.Reader,
-) ([]ScanResult, error) {
+) ([]*ScanResult, error) {
 	u, err := buildSBOMConvertAPIURL(t.apiBaseURL, sbomConvertAPIVersion, t.orgID)
 	if err != nil {
 		return nil, fmt.Errorf("sbom convert api url invalid: %w", err)

--- a/internal/snykclient/types.go
+++ b/internal/snykclient/types.go
@@ -366,7 +366,7 @@ type ScanResultFact struct {
 type ScanResult struct {
 	Name            string             `json:"name"`
 	Policy          string             `json:"policy,omitempty"`
-	Facts           []ScanResultFact   `json:"facts"`
+	Facts           []*ScanResultFact  `json:"facts"`
 	Target          ScanResultTarget   `json:"target"`
 	Identity        ScanResultIdentity `json:"identity"`
 	TargetReference string             `json:"targetReference,omitempty"`
@@ -377,10 +377,10 @@ type ScanResultRequest struct {
 }
 
 type SBOMConvertResponse struct {
-	ScanResults []ScanResult `json:"scanResults"`
+	ScanResults []*ScanResult `json:"scanResults"`
 }
 
-type MonitorDepsResponse struct {
+type MonitorDependenciesResponse struct {
 	OK             bool        `json:"ok"`
 	Org            string      `json:"org"`
 	ID             string      `json:"id"`


### PR DESCRIPTION
Adds methods to augment a ScanResult with target name, target reference and a Snyk Policy.

These are needed to process a `ScanResult` coming from the upstream request and add additional information from the client-side environment.