### PR TITLE
feat: handle errors during monitor sub-command

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -67,6 +67,13 @@ func (ef *ErrorFactory) NewEmptyOrgError() *SBOMExtensionError {
 	)
 }
 
+func (ef *ErrorFactory) NewFeatureNotPermittedError(featureFlag string) *SBOMExtensionError {
+	return ef.newErr(
+		fmt.Errorf("feature %q not permitted", featureFlag),
+		"The feature you are trying to use is not available for your organization.",
+	)
+}
+
 func (ef *ErrorFactory) NewDepGraphWorkflowError(err error) *SBOMExtensionError {
 	return ef.newErr(
 		fmt.Errorf("error while invoking depgraph workflow: %w", err),
@@ -154,6 +161,13 @@ func (ef *ErrorFactory) NewFailedToReadFileError(err error) *SBOMExtensionError 
 	)
 }
 
+func (ef *ErrorFactory) NewFailedToOpenFileError(err error) *SBOMExtensionError {
+	return ef.newErr(
+		err,
+		"failed to open file",
+	)
+}
+
 func (ef *ErrorFactory) NewFileIsDirectoryError() *SBOMExtensionError {
 	return ef.newErr(
 		fmt.Errorf("file is a directory"),
@@ -182,4 +196,18 @@ func (ef *ErrorFactory) NewFatalSBOMTestError(err error) *SBOMExtensionError {
 
 func (ef *ErrorFactory) NewInvalidFilePathError(err error, path string) *SBOMExtensionError {
 	return ef.newErr(err, fmt.Sprintf("The given filepath %q does not exist.", path))
+}
+
+func (ef *ErrorFactory) NewRenderError(err error) *SBOMExtensionError {
+	return ef.newErr(
+		err,
+		"Failed to render the output of the command.",
+	)
+}
+
+func (ef *ErrorFactory) NewSCAError(err error) *SBOMExtensionError {
+	return ef.newErr(
+		err,
+		fmt.Sprintf("There was an error while analyzing the SBOM document: %s", err),
+	)
 }

--- a/internal/snykclient/monitordeps.go
+++ b/internal/snykclient/monitordeps.go
@@ -51,7 +51,7 @@ func (t *SnykClient) MonitorDependencies(
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode) //nolint:goconst // ok to repeat error message.
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
 	var depsResp MonitorDependenciesResponse

--- a/internal/snykclient/sbomconvert_test.go
+++ b/internal/snykclient/sbomconvert_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,18 +49,15 @@ func Test_SBOMConvert_InvalidJSONReturned(t *testing.T) {
 		http.StatusOK,
 	)
 
-	sbomContent := `{"foo":"bar"}`
-
 	mockHTTPClient := mocks.NewMockSBOMService(response)
 
 	client := snykclient.NewSnykClient(mockHTTPClient.Client(), mockHTTPClient.URL, "org1")
 	_, err := client.SBOMConvert(
 		context.Background(),
 		errFactory,
-		bytes.NewBuffer([]byte(sbomContent)),
-	)
+		strings.NewReader(`{"foo":"bar"}`))
 
-	assert.ErrorContains(t, err, "failed to unmarshal JSON response")
+	assert.ErrorContains(t, err, "unexpected EOF")
 }
 
 func Test_SBOMConvert_ServerErrors(t *testing.T) {


### PR DESCRIPTION
Uses the error factory to print meaningful error messages. This is the precursor to a follow-up PR where we also print errors in case monitoring of a single dep-graph fails (in the loop, now a TODO comment).