### PR TITLE
Chore/rename target name flag

### DIFF
--- a/internal/commands/sbommonitor/sbommonitor.go
+++ b/internal/commands/sbommonitor/sbommonitor.go
@@ -45,7 +45,7 @@ func MonitorWorkflow(
 	experimental := config.GetBool(flags.FlagExperimental)
 	filename := config.GetString(flags.FlagFile)
 	policyPath := config.GetString(flags.FlagPolicyPath)
-	targetName := config.GetString(flags.FlagTargetName)
+	remoteRepoURL := config.GetString(flags.FlagRemoteRepoURL)
 	targetRef := config.GetString(flags.FlagTargetReference)
 	errFactory := errors.NewErrorFactory(logger)
 
@@ -102,7 +102,7 @@ func MonitorWorkflow(
 		mres, merr := c.MonitorDependencies(context.Background(), errFactory,
 			s.WithSnykPolicy(plc).
 				WithTargetReference(targetRef).
-				WithTargetName(targetName))
+				WithTargetName(remoteRepoURL))
 		if merr != nil {
 			logger.Println("Failed to monitor dep-graph", merr)
 			// TODO: implement rendering of error

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -33,7 +33,7 @@ const (
 	FlagNugetPkgsFolder              = "packages-folder"
 	FlagUnmanagedMaxDepth            = "max-depth"
 	FlagPolicyPath                   = "policy-path"
-	FlagTargetName                   = "target-name"
+	FlagRemoteRepoURL                = "remote-repo-url"
 	FlagTargetReference              = "target-reference"
 )
 
@@ -90,7 +90,7 @@ func GetSBOMMonitorFlagSet() *pflag.FlagSet {
 	flagSet.Bool(FlagExperimental, false, "Enable experimental sbom monitor command.")
 	flagSet.String(FlagFile, "", "Specify a SBOM file.")
 	flagSet.String(FlagPolicyPath, "", "Manually pass a path to a .snyk policy file.")
-	flagSet.String(FlagTargetName, "", "Specify a name for the target.")
+	flagSet.String(FlagRemoteRepoURL, "", "Set or override the remote URL for the repository that you would like to monitor.")
 	flagSet.String(FlagTargetReference, "", "Specify a reference that differentiates this project, for example, a branch name or version.")
 
 	return flagSet


### PR DESCRIPTION
# What this does
Renames the `--target-name` flag to `--remote-repo-url` to be consistent with the `snyk monitor` command.