### PR TITLE
feat: render successes and errors during monitoring

### DIFF
--- a/internal/commands/sbommonitor/sbommonitor.go
+++ b/internal/commands/sbommonitor/sbommonitor.go
@@ -99,17 +99,16 @@ func MonitorWorkflow(
 
 	for _, s := range scans {
 		logger.Printf("Monitoring dep-graph (%s)\n", s.Identity.Type)
+
 		mres, merr := c.MonitorDependencies(context.Background(), errFactory,
 			s.WithSnykPolicy(plc).
 				WithTargetReference(targetRef).
 				WithTargetName(targetName))
 		if merr != nil {
 			logger.Println("Failed to monitor dep-graph", merr)
-			// TODO: implement rendering of error
-			// r.RenderMonitorError(merr)
-			continue
 		}
-		if err := r.RenderMonitor(mres); err != nil {
+
+		if err := r.RenderMonitor(mres, merr); err != nil {
 			return nil, errFactory.NewRenderError(err)
 		}
 	}

--- a/internal/view/sbommonitor/render.go
+++ b/internal/view/sbommonitor/render.go
@@ -18,15 +18,32 @@ type Renderer struct {
 	renderDivier bool
 }
 
-func (r *Renderer) RenderMonitor(m *snykclient.MonitorDependenciesResponse) error {
+func (r *Renderer) RenderMonitor(m *snykclient.MonitorDependenciesResponse, merr error) error {
+	var title string
+	var uri string
+	var errTitle string
+
+	if m != nil {
+		title = bold.Render(fmt.Sprintf("Monitoring '%s'...", m.ProjectName))
+		uri = m.URI
+	}
+
+	if merr != nil {
+		errTitle = bold.Render("Error")
+	}
+
 	err := monitorProjectDetailsTemplate.Execute(r.w, struct {
 		Title         string
 		URI           string
 		RenderDivider bool
+		Error         error
+		ErrorTitle    string
 	}{
-		Title:         bold.Render(fmt.Sprintf("Monitoring '%s'...", m.ProjectName)),
-		URI:           m.URI,
+		Title:         title,
+		URI:           uri,
 		RenderDivider: r.renderDivier,
+		Error:         merr,
+		ErrorTitle:    errTitle,
 	})
 
 	if err != nil {
@@ -36,8 +53,4 @@ func (r *Renderer) RenderMonitor(m *snykclient.MonitorDependenciesResponse) erro
 	r.renderDivier = true
 
 	return nil
-}
-
-func (*Renderer) RenderMonitorError(err error) {
-	panic("not implemented")
 }

--- a/internal/view/sbommonitor/render_test.go
+++ b/internal/view/sbommonitor/render_test.go
@@ -2,6 +2,7 @@ package sbommonitor
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,7 +18,7 @@ func TestRenderer_RenderMonitor(t *testing.T) {
 	require.NoError(t, r.RenderMonitor(
 		&snykclient.MonitorDependenciesResponse{
 			ProjectName: "Test Project",
-			URI:         "https://example.com/test_project"}))
+			URI:         "https://example.com/test_project"}, nil))
 
 	out := buf.String()
 
@@ -34,11 +35,11 @@ func TestRenderer_RenderMonitor_MultipleProjects(t *testing.T) {
 	require.NoError(t, r.RenderMonitor(
 		&snykclient.MonitorDependenciesResponse{
 			ProjectName: "Test Project",
-			URI:         "https://example.com/test_project"}))
+			URI:         "https://example.com/test_project"}, nil))
 	require.NoError(t, r.RenderMonitor(
 		&snykclient.MonitorDependenciesResponse{
 			ProjectName: "A Different Project",
-			URI:         "https://example.com/different_project"}))
+			URI:         "https://example.com/different_project"}, nil))
 
 	out := buf.String()
 
@@ -47,5 +48,21 @@ func TestRenderer_RenderMonitor_MultipleProjects(t *testing.T) {
 	assert.Contains(t, out, "A Different Project")
 	assert.Contains(t, out, "https://example.com/different_project")
 
-	snapshotter.SnapshotT(t, buf.String())
+	snapshotter.SnapshotT(t, out)
+}
+
+func TestRenderer_RenderMonitor_WithError(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRenderer(&buf)
+
+	require.NoError(t, r.RenderMonitor(
+		&snykclient.MonitorDependenciesResponse{
+			ProjectName: "Test Project",
+			URI:         "https://example.com/test_project"}, nil))
+	require.NoError(t, r.RenderMonitor(
+		nil, errors.New("something is very wrong!")))
+
+	out := buf.String()
+
+	snapshotter.SnapshotT(t, out)
 }

--- a/internal/view/sbommonitor/template.go
+++ b/internal/view/sbommonitor/template.go
@@ -8,10 +8,24 @@ var monitorProjectDetailsTemplate *template.Template = template.Must(
 	template.New("sbomMonitorProject").Parse(
 		`{{ if .RenderDivider }}
 ─────────────────────────────────────────────────────
-{{ end }}
-{{.Title}}
 
-Explore this snapshot at {{.URI}}
+{{ end -}}
+{{- if .Error -}}
+
+{{ .ErrorTitle }}
+
+An error occurred while attempting to monitor parts of the SBOM document.
+
+Details:
+	{{ .Error }}
+
+{{- else -}}
+
+{{ .Title }}
+
+Explore this snapshot at {{ .URI }}
 
 Notifications about newly disclosed issues related to these dependencies will be emailed to you.
+
+{{- end }}
 `))

--- a/internal/view/sbommonitor/testdata/snapshots/TestRenderer_RenderMonitor
+++ b/internal/view/sbommonitor/testdata/snapshots/TestRenderer_RenderMonitor
@@ -1,4 +1,3 @@
-
 [1mMonitoring 'Test Project'...[0m
 
 Explore this snapshot at https://example.com/test_project

--- a/internal/view/sbommonitor/testdata/snapshots/TestRenderer_RenderMonitor_WithError
+++ b/internal/view/sbommonitor/testdata/snapshots/TestRenderer_RenderMonitor_WithError
@@ -6,9 +6,10 @@ Notifications about newly disclosed issues related to these dependencies will be
 
 ─────────────────────────────────────────────────────
 
-[1mMonitoring 'A Different Project'...[0m
+[1mError[0m
 
-Explore this snapshot at https://example.com/different_project
+An error occurred while attempting to monitor parts of the SBOM document.
 
-Notifications about newly disclosed issues related to these dependencies will be emailed to you.
+Details:
+	something is very wrong!
 


### PR DESCRIPTION
Renders the details of an error when monitoring fails (single request to Registry).

This is mostly a "beta" version, since:
* we don't have any good design for this
* the copy isn't vetted
* we'd likely like to include a request ID, coming in a future PR

<img width="980" alt="image" src="https://github.com/user-attachments/assets/71674fb4-7d86-480a-bf96-ba3f51184675" />
