### PR TITLE
fix: close the input file descriptor when done

### DIFF
--- a/internal/commands/sbommonitor/sbommonitor.go
+++ b/internal/commands/sbommonitor/sbommonitor.go
@@ -78,6 +78,7 @@ func MonitorWorkflow(
 	if err != nil {
 		return nil, errFactory.NewFailedToOpenFileError(err)
 	}
+	defer fd.Close()
 
 	c := snykclient.NewSnykClient(
 		ictx.GetNetworkAccess().GetHttpClient(),


### PR DESCRIPTION
Tiny fix where we forgot to close the file descriptor that we open for the SBOM file.