### PR TITLE
Show Snyk RequestId for server errors

### DIFF
--- a/internal/snykclient/helpers.go
+++ b/internal/snykclient/helpers.go
@@ -47,3 +47,13 @@ func errorDocumentToString(err errorDocument) string {
 func errorObjectToString(err *errorObject) string {
 	return fmt.Sprintf("%s %s: %s", err.Status, err.Title, err.Detail)
 }
+
+func errorWithRequestID(message string, r *http.Response) error {
+	requestID := r.Header.Get("snyk-request-id")
+
+	if requestID == "" {
+		return fmt.Errorf("%s (%s)", message, r.Status)
+	}
+
+	return fmt.Errorf("%s (%s - requestId: %s)", message, r.Status, requestID)
+}

--- a/internal/snykclient/monitordeps.go
+++ b/internal/snykclient/monitordeps.go
@@ -1,4 +1,3 @@
-//nolint:goconst // Refusing to declare a constant for a string we use in fmt.Errorf.
 package snykclient
 
 import (
@@ -113,7 +112,7 @@ func getErrorFromV1Response(r *http.Response) error {
 	// fails.
 	bod, err := io.ReadAll(r.Body)
 	if err != nil {
-		return fmt.Errorf("unknown error (%s)", r.Status)
+		return errorWithRequestID("unknown error (%s)", r)
 	}
 
 	var apiErr v1APIErr
@@ -121,12 +120,12 @@ func getErrorFromV1Response(r *http.Response) error {
 		// We're dealing with JSON.
 		if len(apiErr.Errors) > 0 {
 			// JSON:API error object. Use the first item, it's likely the only one.
-			return fmt.Errorf("%s (%s)", apiErr.Errors[0].Details, r.Status)
+			return errorWithRequestID(apiErr.Errors[0].Details, r)
 		}
 
-		return fmt.Errorf("%s (%s)", apiErr.Message, r.Status)
+		return errorWithRequestID(apiErr.Message, r)
 	}
 
 	// Not JSON. Use the body as raw text.
-	return fmt.Errorf("%s (%s)", bod, r.Status)
+	return errorWithRequestID(string(bod), r)
 }

--- a/internal/snykclient/sbomconvert.go
+++ b/internal/snykclient/sbomconvert.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -55,15 +54,12 @@ func (t *SnykClient) SBOMConvert(
 	}
 	defer resp.Body.Close()
 
-	// TODO: when server-side things go wrong, we should be displaying a
-	// request ID, interaction ID.
-
 	if resp.StatusCode > 399 && resp.StatusCode < 500 {
-		return nil, errFactory.NewSCAError(fmt.Errorf("request to analyze SBOM document was rejected: %s", resp.Status))
+		return nil, errFactory.NewSCAError(errorWithRequestID("request to analyze SBOM document was rejected", resp))
 	}
 
 	if resp.StatusCode > 499 {
-		return nil, errFactory.NewSCAError(fmt.Errorf("analysis of SBOM document failed due to error: %s", resp.Status))
+		return nil, errFactory.NewSCAError(errorWithRequestID("analysis of SBOM document failed due to error", resp))
 	}
 
 	var convertResp SBOMConvertResponse


### PR DESCRIPTION
This PR adds support for including the `snyk-request-id` in error messages received from Snyk services. This will help with debugging issues during the closed beta.

#### Notes
- This is a minimal implementation to expose the request ID to users.
- In future iterations:
  - These errors will be mapped to entries in the error catalogue.
  - The `go-application-framework` will be used to standardise showing the error along with the request ID.