### PR TITLE
feat: require remote repo url flag

### DIFF
--- a/internal/commands/sbommonitor/sbommonitor.go
+++ b/internal/commands/sbommonitor/sbommonitor.go
@@ -68,6 +68,12 @@ func MonitorWorkflow(
 		return nil, errFactory.NewEmptyOrgError()
 	}
 
+	if remoteRepoURL == "" {
+		// TODO: try and get from git context
+
+		return nil, errFactory.NewMissingRemoteRepoUrlError()
+	}
+
 	if filename == "" {
 		return nil, errFactory.NewMissingFilenameFlagError()
 	}

--- a/internal/commands/sbommonitor/sbommonitor_test.go
+++ b/internal/commands/sbommonitor/sbommonitor_test.go
@@ -1,0 +1,82 @@
+package sbommonitor_test
+
+import (
+	_ "embed"
+	"io"
+	"log"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/mocks"
+	"github.com/snyk/go-application-framework/pkg/networking"
+	"github.com/snyk/go-application-framework/pkg/runtimeinfo"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/cli-extension-sbom/internal/commands/sbommonitor"
+)
+
+func TestSBOMMonitorWorkflow_NoExperimentalFlag(t *testing.T) {
+	mockICTX := createMockICTX(t)
+
+	_, err := sbommonitor.MonitorWorkflow(mockICTX, []workflow.Data{})
+
+	assert.ErrorContains(t, err, "Flag `--experimental` is required to execute this command.")
+}
+
+func TestSBOMMonitorWorkflow_NoRemoteRepoURL(t *testing.T) {
+	mockICTX := createMockICTX(t)
+	mockICTX.GetConfiguration().Set("experimental", true)
+	mockICTX.GetConfiguration().Set(sbommonitor.FeatureFlagSBOMMonitor, true)
+
+	_, err := sbommonitor.MonitorWorkflow(mockICTX, []workflow.Data{})
+
+	assert.ErrorContains(t, err, "Can't determine remote URL automatically, please set a remote URL with `--remote-repo-url` flag.")
+}
+
+func createMockICTX(t *testing.T) workflow.InvocationContext {
+	t.Helper()
+
+	return createMockICTXWithURL(t, "")
+}
+
+func createMockICTXWithURL(t *testing.T, sbomServiceURL string) workflow.InvocationContext {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	return mockInvocationContext(t, ctrl, sbomServiceURL, nil)
+}
+
+func mockInvocationContext(
+	t *testing.T,
+	ctrl *gomock.Controller,
+	sbomServiceURL string,
+	mockEngine *mocks.MockEngine,
+) workflow.InvocationContext {
+	t.Helper()
+
+	mockLogger := log.New(io.Discard, "", 0)
+
+	mockConfig := configuration.New()
+	mockConfig.Set(configuration.AUTHENTICATION_TOKEN, "<SOME API TOKEN>")
+	mockConfig.Set(configuration.ORGANIZATION, "6277734c-fc84-4c74-9662-33d46ec66c53")
+	mockConfig.Set(configuration.API_URL, sbomServiceURL)
+	mockConfig.Set("format", "cyclonedx1.4+json")
+	mockConfig.Set("name", "goof")
+	mockConfig.Set("version", "0.0.0")
+
+	mockRuntimeInfo := runtimeinfo.New(
+		runtimeinfo.WithName("test-app"),
+		runtimeinfo.WithVersion("1.2.3"))
+
+	ictx := mocks.NewMockInvocationContext(ctrl)
+	ictx.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
+	ictx.EXPECT().GetEngine().Return(mockEngine).AnyTimes()
+	ictx.EXPECT().GetNetworkAccess().Return(networking.NewNetworkAccess(mockConfig)).AnyTimes()
+	ictx.EXPECT().GetLogger().Return(mockLogger).AnyTimes()
+	ictx.EXPECT().GetRuntimeInfo().Return(mockRuntimeInfo).AnyTimes()
+
+	return ictx
+}

--- a/internal/commands/sbommonitor/sbommonitor_test.go
+++ b/internal/commands/sbommonitor/sbommonitor_test.go
@@ -1,9 +1,12 @@
 package sbommonitor_test
 
 import (
+	"bytes"
 	_ "embed"
 	"io"
 	"log"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -13,9 +16,18 @@ import (
 	"github.com/snyk/go-application-framework/pkg/runtimeinfo"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/cli-extension-sbom/internal/commands/sbommonitor"
+	"github.com/snyk/cli-extension-sbom/internal/flags"
+	svcmocks "github.com/snyk/cli-extension-sbom/internal/mocks"
 )
+
+//go:embed testdata/sbom-test-convert.response.json
+var testResultMockResponse []byte
+
+//go:embed testdata/registry-monitor-dependencies.response.json
+var monitorDependenciesResultMockResponse []byte
 
 func TestSBOMMonitorWorkflow_NoExperimentalFlag(t *testing.T) {
 	mockICTX := createMockICTX(t)
@@ -33,6 +45,50 @@ func TestSBOMMonitorWorkflow_NoRemoteRepoURL(t *testing.T) {
 	_, err := sbommonitor.MonitorWorkflow(mockICTX, []workflow.Data{})
 
 	assert.ErrorContains(t, err, "Can't determine remote URL automatically, please set a remote URL with `--remote-repo-url` flag.")
+}
+
+func TestSBOMMonitorWorkflow_PassRemoteRepoURL(t *testing.T) {
+	remoteGitURL := "https://example.com/flag-url"
+
+	responses := []svcmocks.MockResponse{
+		svcmocks.NewMockResponse("application/vnd.api+json", testResultMockResponse, http.StatusOK),
+		svcmocks.NewMockResponse("application/vnd.api+json", monitorDependenciesResultMockResponse, http.StatusOK),
+	}
+
+	var monitorDependenciesRequestBody string
+
+	mockSBOMService := svcmocks.NewMockSBOMServiceMultiResponse(responses, func(r *http.Request) {
+		if strings.Contains(r.RequestURI, "monitor-dependencies") {
+			var err error
+			monitorDependenciesRequestBody, err = processRequest(r)
+			require.NoError(t, err)
+		}
+	})
+	defer mockSBOMService.Close()
+
+	mockICTX := createMockICTXWithURL(t, mockSBOMService.URL)
+	mockICTX.GetConfiguration().Set("experimental", true)
+	mockICTX.GetConfiguration().Set(sbommonitor.FeatureFlagSBOMMonitor, true)
+	mockICTX.GetConfiguration().Set(flags.FlagRemoteRepoURL, remoteGitURL)
+	mockICTX.GetConfiguration().Set("file", "testdata/bom.json")
+
+	_, err := sbommonitor.MonitorWorkflow(mockICTX, []workflow.Data{})
+
+	require.NoError(t, err)
+
+	assert.Contains(t, monitorDependenciesRequestBody, remoteGitURL, "Request body should contain remote repo URL")
+}
+
+func processRequest(r *http.Request) (string, error) {
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		return "", err
+	}
+
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	bodyString := string(bodyBytes)
+	return bodyString, nil
 }
 
 func createMockICTX(t *testing.T) workflow.InvocationContext {

--- a/internal/commands/sbommonitor/testdata/bom.json
+++ b/internal/commands/sbommonitor/testdata/bom.json
@@ -1,0 +1,44 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuid:78933f9a-cf34-45a0-bfef-b8201b8e1ab9",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2023-10-05T15:21:44+02:00",
+    "tools": [
+      {
+        "vendor": "CycloneDX",
+        "name": "cyclonedx-gomod",
+        "version": "v1.4.0",
+        "externalReferences": [
+          {
+            "url": "https://github.com/CycloneDX/cyclonedx-gomod",
+            "type": "vcs"
+          },
+          {
+            "url": "https://cyclonedx.org",
+            "type": "website"
+          }
+        ]
+      }
+    ],
+    "component": {
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.3?type=module",
+      "type": "application",
+      "name": "gopkg.in/yaml.v2",
+      "version": "v2.2.3",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.3?type=module\u0026goos=darwin\u0026goarch=arm64",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-yaml/yaml",
+          "type": "vcs"
+        }
+      ]
+    }
+  },
+  "dependencies": [
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.3?type=module"
+    }
+  ]
+}

--- a/internal/commands/sbommonitor/testdata/registry-monitor-dependencies.response.json
+++ b/internal/commands/sbommonitor/testdata/registry-monitor-dependencies.response.json
@@ -1,0 +1,7 @@
+{
+	"ok": true,
+	"id": "abc-123",
+	"isMonitored": true,
+	"uri": "",
+	"projectName": "myProjectName"
+}

--- a/internal/commands/sbommonitor/testdata/sbom-test-convert.response.json
+++ b/internal/commands/sbommonitor/testdata/sbom-test-convert.response.json
@@ -1,0 +1,14 @@
+{
+	"scanResults": [
+		{
+			"name": "alice",
+			"policy": "",
+			"target": {
+				"name": "alice-target"
+			},
+			"identity": {
+				"type": "npm"
+			}
+		}
+	]
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -154,6 +154,13 @@ func (ef *ErrorFactory) NewMissingFilenameFlagError() *SBOMExtensionError {
 	)
 }
 
+func (ef *ErrorFactory) NewMissingRemoteRepoUrlError() *SBOMExtensionError {
+	return ef.newErr(
+		fmt.Errorf("remote repo URL not found"),
+		"Can't determine remote URL automatically, please set a remote URL with `--remote-repo-url` flag.",
+	)
+}
+
 func (ef *ErrorFactory) NewFailedToReadFileError(err error) *SBOMExtensionError {
 	return ef.newErr(
 		err,


### PR DESCRIPTION
- Add tests for SBOM Monitor command
- Require the `--remote-repo-url` flag to be set 