### PR TITLE
feat(monitor): return an error when no supported projects were found

### DIFF
--- a/internal/commands/sbommonitor/sbommonitor.go
+++ b/internal/commands/sbommonitor/sbommonitor.go
@@ -109,6 +109,10 @@ func MonitorWorkflowWithDI(
 
 	logger.Println("Successfully converted SBOM")
 
+	if len(scans) < 1 {
+		return nil, errFactory.NewNoSupportedProjectsError()
+	}
+
 	plc := policy.LoadPolicyFile(policyPath, filename)
 
 	var buf bytes.Buffer

--- a/internal/commands/sbommonitor/testdata/sbom-test-convert-no-results.response.json
+++ b/internal/commands/sbommonitor/testdata/sbom-test-convert-no-results.response.json
@@ -1,0 +1,3 @@
+{
+  "scanResults": []
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -218,3 +218,11 @@ func (ef *ErrorFactory) NewSCAError(err error) *SBOMExtensionError {
 		fmt.Sprintf("There was an error while analyzing the SBOM document: %s", err),
 	)
 }
+
+func (ef *ErrorFactory) NewNoSupportedProjectsError() *SBOMExtensionError {
+	return ef.newErr(
+		fmt.Errorf("no supported projects to monitor"),
+		"No supported projects were found in the SBOM you are trying to monitor. "+
+			"Please check that your SBOM contains supported ecosystems and dependency relationships.",
+	)
+}


### PR DESCRIPTION
# What this does?

This introduces a new error which will be returned if no supported projects were found in the SBOM when doing an `snyk sbom monitor`.