### PR TITLE
fix: fix linting errors and add flag to hide reachability

### DIFF
--- a/internal/bundlestore/client.go
+++ b/internal/bundlestore/client.go
@@ -108,6 +108,7 @@ func (c *Client) request(
 	return responseBody, nil
 }
 
+//nolint:gocritic // Code copied verbatim from go-application-framework
 func (c *Client) createBundle(ctx context.Context, fileHashes map[string]string) (string, []string, error) {
 	requestBody, err := json.Marshal(fileHashes)
 	if err != nil {
@@ -127,6 +128,7 @@ func (c *Client) createBundle(ctx context.Context, fileHashes map[string]string)
 	return bundle.BundleHash, bundle.MissingFiles, nil
 }
 
+//nolint:gocritic // Code copied verbatim from go-application-framework
 func (c *Client) extendBundle(ctx context.Context, bundleHash string, files map[string]BundleFile, removedFiles []string) (string, []string, error) {
 	requestBody, err := json.Marshal(ExtendBundleRequest{
 		Files:        files,

--- a/internal/bundlestore/config.go
+++ b/internal/bundlestore/config.go
@@ -22,6 +22,7 @@ func (c *codeClientConfig) IsFedramp() bool {
 }
 
 func (c *codeClientConfig) SnykCodeApi() string {
+	//nolint:gocritic // Code copied verbatim from go-application-framework
 	return strings.Replace(c.localConfiguration.GetString(configuration.API_URL), "api", "deeproxy", -1)
 }
 

--- a/internal/bundlestore/encoding.go
+++ b/internal/bundlestore/encoding.go
@@ -27,9 +27,11 @@ func (ew *EncoderWriter) Write(b []byte) (int, error) {
 		return n, err
 	}
 
+	//nolint:gocritic // Code copied verbatim from go-application-framework
 	if err = b64Writer.Close(); err != nil {
 		return n, err
 	}
+	//nolint:gocritic // Code copied verbatim from go-application-framework
 	if err = zipWriter.Close(); err != nil {
 		return n, err
 	}

--- a/internal/bundlestore/utils.go
+++ b/internal/bundlestore/utils.go
@@ -14,7 +14,7 @@ import (
 
 func hash(content []byte) string {
 	byteReader := bytes.NewReader(content)
-	reader, _ := charset.NewReaderLabel("UTF-8", byteReader)
+	reader, _ := charset.NewReaderLabel("UTF-8", byteReader) //nolint:errcheck // Code copied verbatim from go-application-framework
 	utf8content, err := io.ReadAll(reader)
 	if err != nil {
 		utf8content = content
@@ -42,6 +42,7 @@ func encodeRequestBody(requestBody []byte) (*bytes.Buffer, error) {
 	return b, nil
 }
 
+//nolint:gocritic // Code copied verbatim from go-application-framework
 func toRelativeUnixPath(baseDir string, absoluteFilePath string) (string, error) {
 	relativePath, err := filepath.Rel(baseDir, absoluteFilePath)
 	if err != nil {

--- a/internal/commands/sbomcreate/sbomcreate_test.go
+++ b/internal/commands/sbomcreate/sbomcreate_test.go
@@ -4,12 +4,12 @@ import (
 	_ "embed"
 	"errors"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/rs/zerolog"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/mocks"
 	"github.com/snyk/go-application-framework/pkg/networking"
@@ -212,7 +212,7 @@ func mockInvocationContext(
 ) workflow.InvocationContext {
 	t.Helper()
 
-	mockLogger := log.New(io.Discard, "", 0)
+	mockLogger := zerolog.New(io.Discard)
 
 	mockConfig := configuration.New()
 	mockConfig.Set(configuration.AUTHENTICATION_TOKEN, "<SOME API TOKEN>")
@@ -238,7 +238,7 @@ func mockInvocationContext(
 	ictx.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
 	ictx.EXPECT().GetEngine().Return(mockEngine).AnyTimes()
 	ictx.EXPECT().GetNetworkAccess().Return(networking.NewNetworkAccess(mockConfig)).AnyTimes()
-	ictx.EXPECT().GetLogger().Return(mockLogger).AnyTimes()
+	ictx.EXPECT().GetEnhancedLogger().Return(&mockLogger).AnyTimes()
 	ictx.EXPECT().GetRuntimeInfo().Return(mockRuntimeInfo).AnyTimes()
 
 	return ictx

--- a/internal/commands/sbomtest/sbomtest_test.go
+++ b/internal/commands/sbomtest/sbomtest_test.go
@@ -3,11 +3,11 @@ package sbomtest_test
 import (
 	_ "embed"
 	"io"
-	"log"
 	"net/http"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/rs/zerolog"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/content_type"
 	"github.com/snyk/go-application-framework/pkg/mocks"
@@ -142,7 +142,7 @@ func mockInvocationContext(
 ) workflow.InvocationContext {
 	t.Helper()
 
-	mockLogger := log.New(io.Discard, "", 0)
+	mockLogger := zerolog.New(io.Discard)
 
 	mockConfig := configuration.New()
 	mockConfig.Set(configuration.AUTHENTICATION_TOKEN, "<SOME API TOKEN>")
@@ -160,7 +160,7 @@ func mockInvocationContext(
 	ictx.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
 	ictx.EXPECT().GetEngine().Return(mockEngine).AnyTimes()
 	ictx.EXPECT().GetNetworkAccess().Return(networking.NewNetworkAccess(mockConfig)).AnyTimes()
-	ictx.EXPECT().GetLogger().Return(mockLogger).AnyTimes()
+	ictx.EXPECT().GetEnhancedLogger().Return(&mockLogger).AnyTimes()
 	ictx.EXPECT().GetRuntimeInfo().Return(mockRuntimeInfo).AnyTimes()
 
 	return ictx

--- a/internal/sbom/loader_test.go
+++ b/internal/sbom/loader_test.go
@@ -3,9 +3,9 @@ package sbom_test
 import (
 	"bytes"
 	_ "embed"
-	"log"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/cli-extension-sbom/internal/errors"
@@ -15,8 +15,8 @@ import (
 //go:embed testdata/bom.json
 var sbomJson string
 
-var logger = log.New(&bytes.Buffer{}, "", 0)
-var errFactory = errors.NewErrorFactory(logger)
+var logger = zerolog.New(&bytes.Buffer{})
+var errFactory = errors.NewErrorFactory(&logger)
 
 func TestIsSBOMJSON(t *testing.T) {
 	testCases := []struct {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 
 	"github.com/rs/zerolog"
+
 	"github.com/snyk/cli-extension-sbom/internal/errors"
 )
 

--- a/internal/snykclient/snykclient_test.go
+++ b/internal/snykclient/snykclient_test.go
@@ -3,10 +3,10 @@ package snykclient_test
 import (
 	"bytes"
 	_ "embed"
-	"log"
 	"net/http"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/cli-extension-sbom/internal/errors"
@@ -16,8 +16,8 @@ import (
 //go:embed testdata/sbom-test-result.response.json
 var testResultMockResponse []byte
 
-var logger = log.New(&bytes.Buffer{}, "", 0)
-var errFactory = errors.NewErrorFactory(logger)
+var logger = zerolog.New(&bytes.Buffer{})
+var errFactory = errors.NewErrorFactory(&logger)
 
 func TestNewSnykClient(t *testing.T) {
 	client := snykclient.NewSnykClient(http.DefaultClient, "http://example.com", "org1")


### PR DESCRIPTION
This PR fixes linting errors and unit test failures in the `wip/reachability` branch, and adds a boolean flag which looks up an environment variable to guard the new code path. This will allow us to merge the feature branch into main without exposing any of the functionality (unless users have dug through the source code and know about the feature flag but we think this is an okay approach - we're waiting on confirmation [here](https://snyk.slack.com/archives/C073HFTPLSF/p1744642155947399)).