### PR TITLE
feat: fallback to remote-repo-url for unnamed projects

### DIFF
--- a/internal/commands/sbommonitor/sbommonitor.go
+++ b/internal/commands/sbommonitor/sbommonitor.go
@@ -47,7 +47,7 @@ func MonitorWorkflow(
 func MonitorWorkflowWithDI(
 	ictx workflow.InvocationContext,
 	_ []workflow.Data,
-	remoteRepoUrlGetter cmd_exec.RemoteRepoURLGetter,
+	remoteRepoURLGetter cmd_exec.RemoteRepoURLGetter,
 ) ([]workflow.Data, error) {
 	config := ictx.GetConfiguration()
 	logger := ictx.GetLogger()
@@ -78,10 +78,13 @@ func MonitorWorkflowWithDI(
 	}
 
 	if remoteRepoURL == "" {
-		remoteRepoURL = remoteRepoUrlGetter.GetRemoteOriginURL()
-		if remoteRepoURL == "" {
-			return nil, errFactory.NewMissingRemoteRepoUrlError()
-		}
+		remoteRepoURL = remoteRepoURLGetter.GetRemoteOriginURL()
+	}
+
+	logger.Println("Remote Repository URL:", remoteRepoURL)
+
+	if remoteRepoURL == "" {
+		return nil, errFactory.NewMissingRemoteRepoUrlError()
 	}
 
 	if filename == "" {
@@ -124,7 +127,8 @@ func MonitorWorkflowWithDI(
 		mres, merr := c.MonitorDependencies(context.Background(), errFactory,
 			s.WithSnykPolicy(plc).
 				WithTargetReference(targetRef).
-				WithTargetRemoteURL(remoteRepoURL))
+				WithTargetRemoteURL(remoteRepoURL).
+				WithProjectIdentity(remoteRepoURL))
 		if merr != nil {
 			logger.Println("Failed to monitor dep-graph", merr)
 		}

--- a/internal/snykclient/monitordeps.go
+++ b/internal/snykclient/monitordeps.go
@@ -85,6 +85,13 @@ func (r *ScanResult) WithTargetReference(ref string) *ScanResult {
 	return r
 }
 
+func (r *ScanResult) WithProjectIdentity(fallback string) *ScanResult {
+	if r.Name == "" {
+		r.Name = r.Identity.Type + ":" + fallback
+	}
+	return r
+}
+
 // getErrorFromV1Response parses an error response from the v1 API
 // and formats it into a human-readable string.
 //

--- a/internal/snykclient/monitordeps_test.go
+++ b/internal/snykclient/monitordeps_test.go
@@ -129,3 +129,14 @@ func TestScanResult_WithTargetReference(t *testing.T) {
 
 	assert.Equal(t, "main", r.TargetReference)
 }
+
+func TestScanResult_WithProjectIdentity(t *testing.T) {
+	r := snykclient.ScanResult{
+		Name:     "",
+		Identity: snykclient.ScanResultIdentity{Type: "npm"},
+	}
+
+	r.WithProjectIdentity("example-app")
+
+	assert.Equal(t, "npm:example-app", r.Name)
+}


### PR DESCRIPTION
This will set the project name to `<ecosystem>:<remote-repo-url>` for projects that come unnamed from the SBOM conversion.