### PR TITLE
feat: send remote_repo_url during SBOM conversion

### DIFF
--- a/internal/commands/sbommonitor/sbommonitor.go
+++ b/internal/commands/sbommonitor/sbommonitor.go
@@ -79,9 +79,6 @@ func MonitorWorkflowWithDI(
 
 	if remoteRepoURL == "" {
 		remoteRepoURL = remoteRepoUrlGetter.GetRemoteOriginURL()
-		if remoteRepoURL == "" {
-			return nil, errFactory.NewMissingRemoteRepoUrlError()
-		}
 	}
 
 	if filename == "" {
@@ -89,6 +86,12 @@ func MonitorWorkflowWithDI(
 	}
 
 	logger.Println("Target file:", filename)
+
+	if remoteRepoURL == "" {
+		return nil, errFactory.NewMissingRemoteRepoUrlError()
+	}
+
+	logger.Println("Remote repo URL:", remoteRepoURL)
 
 	fd, err := os.Open(filename)
 	if err != nil {
@@ -101,7 +104,7 @@ func MonitorWorkflowWithDI(
 		config.GetString(configuration.API_URL),
 		orgID)
 
-	scans, warnings, err := c.SBOMConvert(context.Background(), errFactory, fd)
+	scans, warnings, err := c.SBOMConvert(context.Background(), errFactory, fd, remoteRepoURL)
 	if err != nil {
 		// Snyk Client returns err from error factory
 		return nil, err

--- a/internal/commands/sbommonitor/sbommonitor_test.go
+++ b/internal/commands/sbommonitor/sbommonitor_test.go
@@ -52,6 +52,7 @@ func TestSBOMMonitorWorkflow_NoExperimentalFlag(t *testing.T) {
 func TestSBOMMonitorWorkflow_NoRemoteRepoURL(t *testing.T) {
 	mockICTX := createMockICTX(t)
 	mockICTX.GetConfiguration().Set("experimental", true)
+	mockICTX.GetConfiguration().Set("file", "testdata/bom.json")
 	mockICTX.GetConfiguration().Set(sbommonitor.FeatureFlagSBOMMonitor, true)
 
 	g := &GitStub{remoteOriginURL: ""}

--- a/internal/snykclient/sbomconvert.go
+++ b/internal/snykclient/sbomconvert.go
@@ -21,8 +21,9 @@ func (t *SnykClient) SBOMConvert(
 	ctx context.Context,
 	errFactory *errors.ErrorFactory,
 	sbom io.Reader,
+	remoteRepoURL string,
 ) ([]*ScanResult, []*ConversionWarning, error) {
-	u, err := buildSBOMConvertAPIURL(t.apiBaseURL, sbomConvertAPIVersion, t.orgID)
+	u, err := buildSBOMConvertAPIURL(t.apiBaseURL, sbomConvertAPIVersion, t.orgID, remoteRepoURL)
 	if err != nil {
 		return nil, nil, errFactory.NewSCAError(err)
 	}
@@ -71,7 +72,7 @@ func (t *SnykClient) SBOMConvert(
 	return convertResp.ScanResults, convertResp.ConversionWarning, nil
 }
 
-func buildSBOMConvertAPIURL(apiBaseURL, apiVersion, orgID string) (*url.URL, error) {
+func buildSBOMConvertAPIURL(apiBaseURL, apiVersion, orgID, remoteRepoURL string) (*url.URL, error) {
 	u, err := url.Parse(apiBaseURL)
 	if err != nil {
 		return nil, err
@@ -79,7 +80,10 @@ func buildSBOMConvertAPIURL(apiBaseURL, apiVersion, orgID string) (*url.URL, err
 
 	u = u.JoinPath("hidden", "orgs", orgID, "sboms", "convert")
 
-	query := url.Values{"version": {apiVersion}}
+	query := url.Values{
+		"version":         {apiVersion},
+		"remote_repo_url": {remoteRepoURL},
+	}
 	u.RawQuery = query.Encode()
 
 	return u, nil


### PR DESCRIPTION
This makes the `remote_repo_url` (target identity) part of the SBOM conversion request, so that it can be used as a fallback value when constructing project identities.