### PR TITLE
chore: update env var name

### DIFF
--- a/internal/commands/sbomtest/sbomtest.go
+++ b/internal/commands/sbomtest/sbomtest.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
-	"os"
 
 	"github.com/rs/zerolog"
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
@@ -63,7 +62,7 @@ func TestWorkflow(
 
 	logger.Println("Target SBOM document:", filename)
 
-	isReachabilityEnabled := os.Getenv("SNYK_DEV_REACHABILITY") == "true"
+	isReachabilityEnabled := config.GetBool("INTERNAL_SNYK_DEV_REACHABILITY")
 	if isReachabilityEnabled {
 		return sbomTestReachability(ctx, config, ictx, logger, filename)
 	} else {

--- a/internal/commands/sbomtest/sbomtest_reachability_test.go
+++ b/internal/commands/sbomtest/sbomtest_reachability_test.go
@@ -47,7 +47,7 @@ func TestSBOMTestWorkflow_Reachability(t *testing.T) {
 	mockICTX.GetConfiguration().Set("file", "testdata/bom.json")
 	mockICTX.GetConfiguration().Set("json", true)
 
-	t.Setenv("SNYK_DEV_REACHABILITY", "true")
+	t.Setenv("INTERNAL_SNYK_DEV_REACHABILITY", "true")
 
 	_, err = sbomtest.TestWorkflow(mockICTX, []workflow.Data{})
 	require.NoError(t, err)


### PR DESCRIPTION
Updates the environment variable guarding the reachability work based on the guidance [here](https://snyk.slack.com/archives/C073HFTPLSF/p1744737767059279?thread_ts=1744642155.947399&cid=C073HFTPLSF):
- Adds `INTERNAL_` prefix
- Uses `config.GetBool` instead of `os.Getenv`