### PR TITLE
chore: remove git origin sanitisation logic

### DIFF
--- a/internal/cmd_exec/cmd_exec.go
+++ b/internal/cmd_exec/cmd_exec.go
@@ -1,10 +1,7 @@
 package cmd_exec
 
 import (
-	"fmt"
-	"net/url"
 	"os/exec"
-	"regexp"
 	"strings"
 )
 
@@ -24,30 +21,13 @@ func NewRemoteRepoURLGetter(c cmdExecutor) *cliRemoteRepoURLGetter {
 	return &cliRemoteRepoURLGetter{exec: c}
 }
 
-var originRegex = regexp.MustCompile(`(.+@)?(.+):(.+$)`)
-
 func (g *cliRemoteRepoURLGetter) GetRemoteOriginURL() string {
 	origin, err := g.exec.Exec("git", "remote", "get-url", "origin")
 	if err != nil {
 		return ""
 	}
 
-	origin = strings.TrimSpace(origin)
-	if origin == "" {
-		return ""
-	}
-
-	u, err := url.Parse(origin)
-	if err == nil && u.Host != "" && u.Scheme != "" && (u.Scheme == "ssh" || u.Scheme == "http" || u.Scheme == "https") {
-		return fmt.Sprintf("http://%s%s", u.Host, u.Path)
-	} else {
-		matches := originRegex.FindStringSubmatch(origin)
-		if len(matches) == 4 && matches[2] != "" && matches[3] != "" {
-			return fmt.Sprintf("http://%s/%s", matches[2], matches[3])
-		} else {
-			return origin
-		}
-	}
+	return strings.TrimSpace(origin)
 }
 
 type cmdExecutor interface {

--- a/internal/cmd_exec/cmd_exec_test.go
+++ b/internal/cmd_exec/cmd_exec_test.go
@@ -28,22 +28,7 @@ func Test_GetRemoteOriginUrl(t *testing.T) {
 		{
 			name:     "HTTPS",
 			origin:   "https://github.com/snyk/cli-extension-sbom",
-			expected: "http://github.com/snyk/cli-extension-sbom",
-		},
-		{
-			name:     "HTTP",
-			origin:   "http://github.com/snyk/cli-extension-sbom",
-			expected: "http://github.com/snyk/cli-extension-sbom",
-		},
-		{
-			name:     "SSH",
-			origin:   "ssh://git@github.com:snyk/cli-extension-sbom.git",
-			expected: "http://github.com/snyk/cli-extension-sbom.git",
-		},
-		{
-			name:     "SSH - git prefix",
-			origin:   "git@github.com:snyk/cli-extension-sbom.git",
-			expected: "http://github.com/snyk/cli-extension-sbom.git",
+			expected: "https://github.com/snyk/cli-extension-sbom",
 		},
 		{
 			name:     "No match returns input",
@@ -53,7 +38,7 @@ func Test_GetRemoteOriginUrl(t *testing.T) {
 		{
 			name:     "Trims whitespace from command output",
 			origin:   "\ngit@github.com:snyk/cli-extension-sbom.git\n\n",
-			expected: "http://github.com/snyk/cli-extension-sbom.git",
+			expected: "git@github.com:snyk/cli-extension-sbom.git",
 		},
 		{
 			name:     "Whitespace-only output is converted to empty string",


### PR DESCRIPTION
# What this does?

Removes the git origin sanitisation logic since this will now be done on the server side.