### PR TITLE
fix: resolve mismatch between test running in CI and locally

### DIFF
--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
@@ -146,9 +147,16 @@ func TestDepGraphsToSBOM_FailedRequest(t *testing.T) {
 	logger := log.New(&bytes.Buffer{}, "", 0)
 	errFactory := errors.NewErrorFactory(logger)
 
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("Server should not have been contacted")
+	}))
+	serverURL := ts.URL
+	// Immediately close the server to simulate connection refusal
+	ts.Close()
+
 	res, err := DepGraphsToSBOM(
 		http.DefaultClient,
-		"http://0.0.0.0",
+		serverURL,
 		orgID,
 		[]json.RawMessage{[]byte("{}")},
 		nil,


### PR DESCRIPTION
For some reason (I think thanks to Rancher desktop listening on some ports) the `TestDepGraphsToSBOM_FailedRequest` was failing for me locally, as I was getting a 404 compared to `dial tcp 0.0.0.0:80: connect: connection refused` which was happening in CI. This modification ensures that the test works both on CI and locally, by forcing the server to fail the request rather than just hoping that nothing is listening on the URL passed in.