### PR TITLE
chore: fix comments incorrectly referencing GAF

### DIFF
--- a/internal/bundlestore/client.go
+++ b/internal/bundlestore/client.go
@@ -125,7 +125,7 @@ func (c *client) request(
 	return responseBody, nil
 }
 
-//nolint:gocritic // Code copied verbatim from go-application-framework
+//nolint:gocritic // Code copied verbatim from code-client-go
 func (c *client) createBundle(ctx context.Context, fileHashes map[string]string) (string, []string, error) {
 	requestBody, err := json.Marshal(fileHashes)
 	if err != nil {
@@ -145,7 +145,7 @@ func (c *client) createBundle(ctx context.Context, fileHashes map[string]string)
 	return bundle.BundleHash, bundle.MissingFiles, nil
 }
 
-//nolint:gocritic // Code copied verbatim from go-application-framework
+//nolint:gocritic // Code copied verbatim from code-client-go
 func (c *client) extendBundle(ctx context.Context, bundleHash string, files map[string]BundleFile, removedFiles []string) (string, []string, error) {
 	requestBody, err := json.Marshal(ExtendBundleRequest{
 		Files:        files,

--- a/internal/bundlestore/config.go
+++ b/internal/bundlestore/config.go
@@ -22,7 +22,7 @@ func (c *codeClientConfig) IsFedramp() bool {
 }
 
 func (c *codeClientConfig) SnykCodeApi() string {
-	//nolint:gocritic // Code copied verbatim from go-application-framework
+	//nolint:gocritic // Code copied verbatim from code-client-go
 	return strings.Replace(c.localConfiguration.GetString(configuration.API_URL), "api", "deeproxy", -1)
 }
 

--- a/internal/bundlestore/encoding.go
+++ b/internal/bundlestore/encoding.go
@@ -27,11 +27,11 @@ func (ew *EncoderWriter) Write(b []byte) (int, error) {
 		return n, err
 	}
 
-	//nolint:gocritic // Code copied verbatim from go-application-framework
+	//nolint:gocritic // Code copied verbatim from code-client-go
 	if err = b64Writer.Close(); err != nil {
 		return n, err
 	}
-	//nolint:gocritic // Code copied verbatim from go-application-framework
+	//nolint:gocritic // Code copied verbatim from code-client-go
 	if err = zipWriter.Close(); err != nil {
 		return n, err
 	}

--- a/internal/bundlestore/utils.go
+++ b/internal/bundlestore/utils.go
@@ -14,7 +14,7 @@ import (
 
 func hash(content []byte) string {
 	byteReader := bytes.NewReader(content)
-	reader, _ := charset.NewReaderLabel("UTF-8", byteReader) //nolint:errcheck // Code copied verbatim from go-application-framework
+	reader, _ := charset.NewReaderLabel("UTF-8", byteReader) //nolint:errcheck // Code copied verbatim from code-client-go
 	utf8content, err := io.ReadAll(reader)
 	if err != nil {
 		utf8content = content
@@ -42,7 +42,7 @@ func encodeRequestBody(requestBody []byte) (*bytes.Buffer, error) {
 	return b, nil
 }
 
-//nolint:gocritic // Code copied verbatim from go-application-framework
+//nolint:gocritic // Code copied verbatim from code-client-go
 func toRelativeUnixPath(baseDir string, absoluteFilePath string) (string, error) {
 	relativePath, err := filepath.Rel(baseDir, absoluteFilePath)
 	if err != nil {


### PR DESCRIPTION
In [this PR](https://github.com/snyk/cli-extension-sbom/pull/133/files) I incorrectly referred to `go-application-framework` in some comments about the origin of the bundlestore code - in fact we copied this code from `code-client-go`.