### PR TITLE
feat(reachability): use snyk api for uploading SBOMs in fedramp env

### DIFF
--- a/internal/bundlestore/client.go
+++ b/internal/bundlestore/client.go
@@ -77,6 +77,13 @@ func NewClient(config configuration.Configuration, hc codeclienthttp.HTTPClientF
 	}
 }
 
+func (c *client) host() string {
+	if c.codeClientConfig.IsFedramp() {
+		return c.SnykApi() + "/hidden/orgs/" + c.codeClientConfig.Organization() + "/code"
+	}
+	return c.SnykCodeApi()
+}
+
 func (c *client) request(
 	ctx context.Context,
 	method string,
@@ -88,7 +95,7 @@ func (c *client) request(
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, c.SnykCodeApi()+path, bodyBuffer)
+	req, err := http.NewRequestWithContext(ctx, method, c.host()+path, bodyBuffer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# What this does?
When uploading the SBOM in a FedRamp environment we should use the snyk api instead of the deeproxy one, as seen [in code-client-go](https://github.com/snyk/code-client-go/blob/d8776ec05eeba7019489212f4a62f91ed51673d5/internal/deepcode/client.go#L184).