### PR TITLE
feat(reachability): add missing os flows flags

### DIFF
--- a/internal/commands/sbomtest/sbomtest.go
+++ b/internal/commands/sbomtest/sbomtest.go
@@ -22,8 +22,6 @@ var (
 	OsFlowsTestWorkflowID = workflow.NewWorkflowIdentifier("test")
 )
 
-const FlagOSFlowsSBOM = "sbom"
-
 func RegisterWorkflows(e workflow.Engine) error {
 	sbomFlagset := flags.GetSBOMTestFlagSet()
 
@@ -70,12 +68,8 @@ func TestWorkflow(
 	isReachabilityEnabled := config.GetBool(flags.FlagReachability)
 
 	if isReachabilityEnabled {
-		sourceDir := config.GetString(flags.FlagSourceDir)
 		osFlowsTestConfig := config.Clone()
-
-		osFlowsTestConfig.Set(flags.FlagReachability, true)
-		osFlowsTestConfig.Set(FlagOSFlowsSBOM, filename)
-		osFlowsTestConfig.Set(flags.FlagSourceDir, sourceDir)
+		osFlowsTestConfig.Set(flags.FlagSBOM, filename)
 
 		return engine.InvokeWithConfig(OsFlowsTestWorkflowID, osFlowsTestConfig)
 	} else {

--- a/internal/commands/sbomtest/sbomtest_test.go
+++ b/internal/commands/sbomtest/sbomtest_test.go
@@ -136,13 +136,11 @@ func TestSBOMTestWorkflow_ReachabilitySuccess(t *testing.T) {
 	mockICTX := mockInvocationContext(t, ctrl, mockSBOMService.URL, mockEngine)
 	mockICTX.GetConfiguration().Set("experimental", true)
 	mockICTX.GetConfiguration().Set("file", "testdata/bom.json")
-	mockICTX.GetConfiguration().Set("reachability", true)
+	mockICTX.GetConfiguration().Set(flags.FlagReachability, true)
 
 	osFlowsTestConfig := mockICTX.GetConfiguration().Clone()
-
 	osFlowsTestConfig.Set(flags.FlagReachability, true)
-	osFlowsTestConfig.Set(sbomtest.FlagOSFlowsSBOM, "testdata/bom.json")
-	osFlowsTestConfig.Set(flags.FlagSourceDir, "")
+	osFlowsTestConfig.Set(flags.FlagSBOM, "testdata/bom.json")
 
 	mockEngine.EXPECT().InvokeWithConfig(sbomtest.OsFlowsTestWorkflowID, osFlowsTestConfig).Return([]workflow.Data{}, nil).Times(1)
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -35,8 +35,13 @@ const (
 	FlagPolicyPath                   = "policy-path"
 	FlagRemoteRepoURL                = "remote-repo-url"
 	FlagTargetReference              = "target-reference"
-	FlagSourceDir                    = "source-dir"
-	FlagReachability                 = "reachability"
+
+	// OS Flows test flags.
+	FlagReachability       = "reachability"
+	FlagSBOM               = "sbom"
+	FlagSourceDir          = "source-dir"
+	FlagRiskScoreThreshold = "risk-score-threshold"
+	FlagSeverityThreshold  = "severity-threshold"
 )
 
 func GetSBOMCreateFlagSet() *pflag.FlagSet {
@@ -82,8 +87,13 @@ func GetSBOMTestFlagSet() *pflag.FlagSet {
 
 	flagSet.Bool(FlagExperimental, false, "Enable experimental sbom test command.")
 	flagSet.String(FlagFile, "", "Specify an SBOM file.")
+
+	// Flags being forwarded to the os flows test.
+	flagSet.Bool(FlagReachability, false, "Run reachability analysis on source code.")
+	flagSet.String(FlagSBOM, "", "Specify an SBOM file to be tested.")
 	flagSet.String(FlagSourceDir, "", "Path of the directory containing the source code.")
-	flagSet.Bool(FlagReachability, false, "Enable reachability test.")
+	flagSet.Int(FlagRiskScoreThreshold, -1, "Include findings at or over this risk score threshold.")
+	flagSet.String(FlagSeverityThreshold, "", "Report only findings at the specified level or higher.")
 
 	return flagSet
 }


### PR DESCRIPTION
# What this does?

Adds missing flags that need to be passed down to the `cli-extension-os-flows` test command.