### PR TITLE
Feat:CSENG-175 add support of allow incomplete SBOM

### DIFF
--- a/internal/commands/sbomcreate/depgraph.go
+++ b/internal/commands/sbomcreate/depgraph.go
@@ -34,12 +34,13 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 	version := config.GetString(flags.FlagVersion)
 
 	depGraphConfig := config.Clone()
-	if config.GetBool(flags.FlagAllProjects) {
-		allowIncomplete := config.GetBool(flags.FlagAllowIncompleteSBOM)
-		depGraphConfig.Set("fail-fast", !allowIncomplete)
-		if allowIncomplete {
-			depGraphConfig.Set("effective-graph-with-errors", true)
-		}
+	allowIncomplete := config.GetBool(flags.FlagAllowIncompleteSBOM)
+
+	if allowIncomplete {
+		depGraphConfig.Set("fail-fast", false)
+		depGraphConfig.Set("effective-graph-with-errors", true)
+	} else if config.GetBool(flags.FlagAllProjects) {
+		depGraphConfig.Set("fail-fast", true)
 	}
 	useSCAPlugins, err := shouldUseSCAPlugins(config, logger)
 	if err != nil {

--- a/internal/commands/sbomcreate/depgraph.go
+++ b/internal/commands/sbomcreate/depgraph.go
@@ -21,6 +21,7 @@ var DepGraphWorkflowID = workflow.NewWorkflowIdentifier("depgraph")
 type DepGraphResult struct {
 	Name          string
 	DepGraphBytes []json.RawMessage
+	ScanFailures  []string
 }
 
 func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
@@ -33,7 +34,11 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 
 	depGraphConfig := config.Clone()
 	if config.GetBool(flags.FlagAllProjects) {
-		depGraphConfig.Set("fail-fast", true)
+		allowIncomplete := config.GetBool(flags.FlagAllowIncompleteSBOM)
+		depGraphConfig.Set("fail-fast", !allowIncomplete)
+		if allowIncomplete {
+			depGraphConfig.Set("effective-graph-with-errors", true)
+		}
 	}
 	useSCAPlugins, err := shouldUseSCAPlugins(config, logger)
 	if err != nil {
@@ -48,17 +53,33 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 		return nil, errFactory.NewDepGraphWorkflowError(err)
 	}
 
-	numGraphs := len(depGraphs)
-	logger.Printf("Generating documents for %d depgraph(s)\n", numGraphs)
-	depGraphsBytes := make([]json.RawMessage, numGraphs)
-	for i, depGraph := range depGraphs {
-		depGraphBytes, err := getPayloadBytes(depGraph)
+	depGraphsBytes := make([]json.RawMessage, 0, len(depGraphs))
+	var scanFailures []string
+	for _, dg := range depGraphs {
+		if errList := dg.GetErrorList(); len(errList) > 0 {
+			path := dg.GetContentLocation()
+			for _, e := range errList {
+				msg := e.Detail
+				if msg == "" {
+					msg = e.Title
+				}
+				if path != "" {
+					scanFailures = append(scanFailures, fmt.Sprintf("%s: %s", path, msg))
+				} else {
+					scanFailures = append(scanFailures, msg)
+				}
+			}
+			continue
+		}
+		depGraphBytes, err := getPayloadBytes(dg)
 		if err != nil {
 			return nil, errFactory.NewDepGraphWorkflowError(err)
 		}
-		depGraphsBytes[i] = depGraphBytes
+		depGraphsBytes = append(depGraphsBytes, depGraphBytes)
 	}
-	if numGraphs > 1 {
+	numGraphs := len(depGraphsBytes)
+	logger.Printf("Generating documents for %d depgraph(s)\n", numGraphs)
+	if numGraphs != 1 {
 		if name == "" {
 			// Fall back to current working directory
 			wd, err := os.Getwd()
@@ -73,6 +94,7 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 	return &DepGraphResult{
 		Name:          name,
 		DepGraphBytes: depGraphsBytes,
+		ScanFailures:  scanFailures,
 	}, nil
 }
 

--- a/internal/commands/sbomcreate/depgraph.go
+++ b/internal/commands/sbomcreate/depgraph.go
@@ -13,6 +13,7 @@ import (
 	"github.com/snyk/cli-extension-sbom/internal/constants"
 	"github.com/snyk/cli-extension-sbom/internal/errors"
 	"github.com/snyk/cli-extension-sbom/internal/flags"
+	"github.com/snyk/cli-extension-sbom/internal/service"
 	"github.com/snyk/cli-extension-sbom/internal/util"
 )
 
@@ -21,7 +22,7 @@ var DepGraphWorkflowID = workflow.NewWorkflowIdentifier("depgraph")
 type DepGraphResult struct {
 	Name          string
 	DepGraphBytes []json.RawMessage
-	ScanFailures  []string
+	ScanErrors    []service.ScanError
 }
 
 func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
@@ -54,20 +55,16 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 	}
 
 	depGraphsBytes := make([]json.RawMessage, 0, len(depGraphs))
-	var scanFailures []string
+	var scanErrors []service.ScanError
 	for _, dg := range depGraphs {
 		if errList := dg.GetErrorList(); len(errList) > 0 {
-			path := dg.GetContentLocation()
+			subject := dg.GetContentLocation()
 			for i := range errList {
 				msg := errList[i].Detail
 				if msg == "" {
 					msg = errList[i].Title
 				}
-				if path != "" {
-					scanFailures = append(scanFailures, fmt.Sprintf("%s: %s", path, msg))
-				} else {
-					scanFailures = append(scanFailures, msg)
-				}
+				scanErrors = append(scanErrors, service.ScanError{Subject: subject, Text: msg})
 			}
 			continue
 		}
@@ -79,7 +76,7 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 	}
 	numGraphs := len(depGraphsBytes)
 	logger.Printf("Generating documents for %d depgraph(s)\n", numGraphs)
-	if numGraphs != 1 || len(scanFailures) > 0 {
+	if numGraphs != 1 || len(scanErrors) > 0 {
 		if name == "" {
 			// Fall back to current working directory
 			wd, err := os.Getwd()
@@ -94,7 +91,7 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 	return &DepGraphResult{
 		Name:          name,
 		DepGraphBytes: depGraphsBytes,
-		ScanFailures:  scanFailures,
+		ScanErrors:    scanErrors,
 	}, nil
 }
 

--- a/internal/commands/sbomcreate/depgraph.go
+++ b/internal/commands/sbomcreate/depgraph.go
@@ -79,7 +79,7 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 	}
 	numGraphs := len(depGraphsBytes)
 	logger.Printf("Generating documents for %d depgraph(s)\n", numGraphs)
-	if numGraphs != 1 {
+	if numGraphs != 1 || len(scanFailures) > 0 {
 		if name == "" {
 			// Fall back to current working directory
 			wd, err := os.Getwd()

--- a/internal/commands/sbomcreate/depgraph.go
+++ b/internal/commands/sbomcreate/depgraph.go
@@ -58,10 +58,10 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 	for _, dg := range depGraphs {
 		if errList := dg.GetErrorList(); len(errList) > 0 {
 			path := dg.GetContentLocation()
-			for _, e := range errList {
-				msg := e.Detail
+			for i := range errList {
+				msg := errList[i].Detail
 				if msg == "" {
-					msg = e.Title
+					msg = errList[i].Title
 				}
 				if path != "" {
 					scanFailures = append(scanFailures, fmt.Sprintf("%s: %s", path, msg))

--- a/internal/commands/sbomcreate/sbomcreate.go
+++ b/internal/commands/sbomcreate/sbomcreate.go
@@ -72,6 +72,7 @@ func SBOMWorkflow(
 		config.GetString(configuration.API_URL),
 		orgID,
 		depGraphResult.DepGraphBytes,
+		depGraphResult.ScanFailures,
 		service.NewSubject(depGraphResult.Name, version),
 		&service.Tool{Vendor: "Snyk", Name: ri.GetName(), Version: ri.GetVersion()},
 		format,

--- a/internal/commands/sbomcreate/sbomcreate.go
+++ b/internal/commands/sbomcreate/sbomcreate.go
@@ -59,6 +59,7 @@ func SBOMWorkflow(
 	ai := ictx.GetAnalytics()
 	ai.AddExtensionBoolValue(constants.ShowMavenBuildScope, config.GetBool(constants.FeatureFlagShowMavenBuildScope))
 	ai.AddExtensionBoolValue(constants.ShowNpmScope, config.GetBool(constants.FeatureFlagShowNpmScope))
+	ai.AddExtensionBoolValue(constants.AllowIncompleteSBOM, config.GetBool(flags.FlagAllowIncompleteSBOM))
 
 	depGraphResult, err := GetDepGraph(ictx)
 	if err != nil {

--- a/internal/commands/sbomcreate/sbomcreate.go
+++ b/internal/commands/sbomcreate/sbomcreate.go
@@ -72,7 +72,7 @@ func SBOMWorkflow(
 		config.GetString(configuration.API_URL),
 		orgID,
 		depGraphResult.DepGraphBytes,
-		depGraphResult.ScanFailures,
+		depGraphResult.ScanErrors,
 		service.NewSubject(depGraphResult.Name, version),
 		&service.Tool{Vendor: "Snyk", Name: ri.GetName(), Version: ri.GetVersion()},
 		format,

--- a/internal/commands/sbomcreate/sbomcreate_test.go
+++ b/internal/commands/sbomcreate/sbomcreate_test.go
@@ -310,16 +310,17 @@ func assertWorkflowExists(t *testing.T, e workflow.Engine, id *url.URL) {
 	assert.NotNil(t, wflw)
 }
 
-func newDepGraphDataWithError(t *testing.T, path string, err snyk_errors.Error) workflow.Data {
+func newDepGraphDataWithError(t *testing.T, path string, err *snyk_errors.Error) workflow.Data {
 	t.Helper()
 	d := workflow.NewData(
 		workflow.NewTypeIdentifier(sbomcreate.DepGraphWorkflowID, "cyclonedx"),
 		"application/json",
 		[]byte(`{}`),
 	)
-	impl := d.(*workflow.DataImpl)
+	impl, ok := d.(*workflow.DataImpl)
+	require.True(t, ok)
 	impl.SetContentLocation(path)
-	impl.AddError(err)
+	impl.AddError(*err)
 	return d
 }
 
@@ -328,7 +329,7 @@ func TestGetDepGraph_PartialSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	successData := newDepGraphData(t, []byte(`{"pkgManager":{"name":"npm"}}`))
-	errorData := newDepGraphDataWithError(t, "project2/pom.xml", snyk_errors.Error{
+	errorData := newDepGraphDataWithError(t, "project2/pom.xml", &snyk_errors.Error{
 		Title:  "failed to resolve",
 		Detail: "missing lockfile",
 	})
@@ -359,11 +360,11 @@ func TestGetDepGraph_AllErrors_EmptySBOM(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	errorData1 := newDepGraphDataWithError(t, "project1/package.json", snyk_errors.Error{
+	errorData1 := newDepGraphDataWithError(t, "project1/package.json", &snyk_errors.Error{
 		Title:  "scan failed",
 		Detail: "missing lockfile",
 	})
-	errorData2 := newDepGraphDataWithError(t, "project2/pom.xml", snyk_errors.Error{
+	errorData2 := newDepGraphDataWithError(t, "project2/pom.xml", &snyk_errors.Error{
 		Title:  "invalid POM",
 		Detail: "",
 	})
@@ -401,7 +402,8 @@ func TestGetDepGraph_ErrorWithoutPath(t *testing.T) {
 		"application/json",
 		[]byte(`{}`),
 	)
-	impl := d.(*workflow.DataImpl)
+	impl, ok := d.(*workflow.DataImpl)
+	require.True(t, ok)
 	impl.AddError(snyk_errors.Error{Title: "no supported files found"})
 
 	mockEngine := mocks.NewMockEngine(ctrl)

--- a/internal/commands/sbomcreate/sbomcreate_test.go
+++ b/internal/commands/sbomcreate/sbomcreate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/rs/zerolog"
 	"github.com/snyk/error-catalog-golang-public/snyk"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 	"github.com/snyk/go-application-framework/pkg/analytics"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/mocks"
@@ -309,7 +310,7 @@ func assertWorkflowExists(t *testing.T, e workflow.Engine, id *url.URL) {
 	assert.NotNil(t, wflw)
 }
 
-func newDepGraphDataWithError(t *testing.T, path string, err snyk.Error) workflow.Data {
+func newDepGraphDataWithError(t *testing.T, path string, err snyk_errors.Error) workflow.Data {
 	t.Helper()
 	d := workflow.NewData(
 		workflow.NewTypeIdentifier(sbomcreate.DepGraphWorkflowID, "cyclonedx"),
@@ -327,7 +328,7 @@ func TestGetDepGraph_PartialSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	successData := newDepGraphData(t, []byte(`{"pkgManager":{"name":"npm"}}`))
-	errorData := newDepGraphDataWithError(t, "project2/pom.xml", snyk.Error{
+	errorData := newDepGraphDataWithError(t, "project2/pom.xml", snyk_errors.Error{
 		Title:  "failed to resolve",
 		Detail: "missing lockfile",
 	})
@@ -358,11 +359,11 @@ func TestGetDepGraph_AllErrors_EmptySBOM(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	errorData1 := newDepGraphDataWithError(t, "project1/package.json", snyk.Error{
+	errorData1 := newDepGraphDataWithError(t, "project1/package.json", snyk_errors.Error{
 		Title:  "scan failed",
 		Detail: "missing lockfile",
 	})
-	errorData2 := newDepGraphDataWithError(t, "project2/pom.xml", snyk.Error{
+	errorData2 := newDepGraphDataWithError(t, "project2/pom.xml", snyk_errors.Error{
 		Title:  "invalid POM",
 		Detail: "",
 	})
@@ -401,7 +402,7 @@ func TestGetDepGraph_ErrorWithoutPath(t *testing.T) {
 		[]byte(`{}`),
 	)
 	impl := d.(*workflow.DataImpl)
-	impl.AddError(snyk.Error{Title: "no supported files found"})
+	impl.AddError(snyk_errors.Error{Title: "no supported files found"})
 
 	mockEngine := mocks.NewMockEngine(ctrl)
 	mockEngine.EXPECT().

--- a/internal/commands/sbomcreate/sbomcreate_test.go
+++ b/internal/commands/sbomcreate/sbomcreate_test.go
@@ -308,6 +308,122 @@ func assertWorkflowExists(t *testing.T, e workflow.Engine, id *url.URL) {
 	assert.NotNil(t, wflw)
 }
 
+func newDepGraphDataWithError(t *testing.T, path string, err snyk.Error) workflow.Data {
+	t.Helper()
+	d := workflow.NewData(
+		workflow.NewTypeIdentifier(sbomcreate.DepGraphWorkflowID, "cyclonedx"),
+		"application/json",
+		[]byte(`{}`),
+	)
+	impl := d.(*workflow.DataImpl)
+	impl.SetContentLocation(path)
+	impl.AddError(err)
+	return d
+}
+
+func TestGetDepGraph_PartialSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	successData := newDepGraphData(t, []byte(`{"pkgManager":{"name":"npm"}}`))
+	errorData := newDepGraphDataWithError(t, "project2/pom.xml", snyk.Error{
+		Title:  "failed to resolve",
+		Detail: "missing lockfile",
+	})
+
+	mockEngine := mocks.NewMockEngine(ctrl)
+	mockEngine.EXPECT().
+		InvokeWithConfig(gomock.Eq(sbomcreate.DepGraphWorkflowID), gomock.Any()).
+		Return([]workflow.Data{successData, errorData}, nil).
+		Times(1)
+
+	mockLogger := zerolog.New(io.Discard)
+	mockConfig := configuration.New()
+	mockConfig.Set("name", "my-repo")
+
+	mockICTX := mocks.NewMockInvocationContext(ctrl)
+	mockICTX.EXPECT().GetEngine().Return(mockEngine).AnyTimes()
+	mockICTX.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
+	mockICTX.EXPECT().GetEnhancedLogger().Return(&mockLogger).AnyTimes()
+
+	result, err := sbomcreate.GetDepGraph(mockICTX)
+	require.NoError(t, err)
+	assert.Len(t, result.DepGraphBytes, 1, "should have one successful depGraph")
+	assert.Len(t, result.ScanFailures, 1, "should have one scan failure")
+	assert.Equal(t, "project2/pom.xml: missing lockfile", result.ScanFailures[0])
+}
+
+func TestGetDepGraph_AllErrors_EmptySBOM(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	errorData1 := newDepGraphDataWithError(t, "project1/package.json", snyk.Error{
+		Title:  "scan failed",
+		Detail: "missing lockfile",
+	})
+	errorData2 := newDepGraphDataWithError(t, "project2/pom.xml", snyk.Error{
+		Title:  "invalid POM",
+		Detail: "",
+	})
+
+	mockEngine := mocks.NewMockEngine(ctrl)
+	mockEngine.EXPECT().
+		InvokeWithConfig(gomock.Eq(sbomcreate.DepGraphWorkflowID), gomock.Any()).
+		Return([]workflow.Data{errorData1, errorData2}, nil).
+		Times(1)
+
+	mockLogger := zerolog.New(io.Discard)
+	mockConfig := configuration.New()
+	mockConfig.Set("name", "")
+
+	mockICTX := mocks.NewMockInvocationContext(ctrl)
+	mockICTX.EXPECT().GetEngine().Return(mockEngine).AnyTimes()
+	mockICTX.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
+	mockICTX.EXPECT().GetEnhancedLogger().Return(&mockLogger).AnyTimes()
+
+	result, err := sbomcreate.GetDepGraph(mockICTX)
+	require.NoError(t, err)
+	assert.Empty(t, result.DepGraphBytes, "should have zero depGraphs")
+	assert.Len(t, result.ScanFailures, 2, "should have two scan failures")
+	assert.Equal(t, "project1/package.json: missing lockfile", result.ScanFailures[0])
+	assert.Equal(t, "project2/pom.xml: invalid POM", result.ScanFailures[1], "should fall back to Title when Detail is empty")
+	assert.NotEmpty(t, result.Name, "should default name from working directory")
+}
+
+func TestGetDepGraph_ErrorWithoutPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	d := workflow.NewData(
+		workflow.NewTypeIdentifier(sbomcreate.DepGraphWorkflowID, "cyclonedx"),
+		"application/json",
+		[]byte(`{}`),
+	)
+	impl := d.(*workflow.DataImpl)
+	impl.AddError(snyk.Error{Title: "no supported files found"})
+
+	mockEngine := mocks.NewMockEngine(ctrl)
+	mockEngine.EXPECT().
+		InvokeWithConfig(gomock.Eq(sbomcreate.DepGraphWorkflowID), gomock.Any()).
+		Return([]workflow.Data{d}, nil).
+		Times(1)
+
+	mockLogger := zerolog.New(io.Discard)
+	mockConfig := configuration.New()
+	mockConfig.Set("name", "my-repo")
+
+	mockICTX := mocks.NewMockInvocationContext(ctrl)
+	mockICTX.EXPECT().GetEngine().Return(mockEngine).AnyTimes()
+	mockICTX.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
+	mockICTX.EXPECT().GetEnhancedLogger().Return(&mockLogger).AnyTimes()
+
+	result, err := sbomcreate.GetDepGraph(mockICTX)
+	require.NoError(t, err)
+	assert.Empty(t, result.DepGraphBytes)
+	assert.Len(t, result.ScanFailures, 1)
+	assert.Equal(t, "no supported files found", result.ScanFailures[0], "should use message only when no path")
+}
+
 func TestGetDepGraph_uvSupport(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/internal/commands/sbomcreate/sbomcreate_test.go
+++ b/internal/commands/sbomcreate/sbomcreate_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snyk/cli-extension-sbom/internal/constants"
 	"github.com/snyk/cli-extension-sbom/internal/flags"
 	svcmocks "github.com/snyk/cli-extension-sbom/internal/mocks"
+	"github.com/snyk/cli-extension-sbom/internal/service"
 	"github.com/snyk/cli-extension-sbom/pkg/sbom"
 )
 
@@ -349,8 +350,8 @@ func TestGetDepGraph_PartialSuccess(t *testing.T) {
 	result, err := sbomcreate.GetDepGraph(mockICTX)
 	require.NoError(t, err)
 	assert.Len(t, result.DepGraphBytes, 1, "should have one successful depGraph")
-	assert.Len(t, result.ScanFailures, 1, "should have one scan failure")
-	assert.Equal(t, "project2/pom.xml: missing lockfile", result.ScanFailures[0])
+	assert.Len(t, result.ScanErrors, 1, "should have one scan failure")
+	assert.Equal(t, service.ScanError{Subject: "project2/pom.xml", Text: "missing lockfile"}, result.ScanErrors[0])
 }
 
 func TestGetDepGraph_AllErrors_EmptySBOM(t *testing.T) {
@@ -384,9 +385,9 @@ func TestGetDepGraph_AllErrors_EmptySBOM(t *testing.T) {
 	result, err := sbomcreate.GetDepGraph(mockICTX)
 	require.NoError(t, err)
 	assert.Empty(t, result.DepGraphBytes, "should have zero depGraphs")
-	assert.Len(t, result.ScanFailures, 2, "should have two scan failures")
-	assert.Equal(t, "project1/package.json: missing lockfile", result.ScanFailures[0])
-	assert.Equal(t, "project2/pom.xml: invalid POM", result.ScanFailures[1], "should fall back to Title when Detail is empty")
+	assert.Len(t, result.ScanErrors, 2, "should have two scan failures")
+	assert.Equal(t, service.ScanError{Subject: "project1/package.json", Text: "missing lockfile"}, result.ScanErrors[0])
+	assert.Equal(t, service.ScanError{Subject: "project2/pom.xml", Text: "invalid POM"}, result.ScanErrors[1], "should fall back to Title when Detail is empty")
 	assert.NotEmpty(t, result.Name, "should default name from working directory")
 }
 
@@ -420,8 +421,8 @@ func TestGetDepGraph_ErrorWithoutPath(t *testing.T) {
 	result, err := sbomcreate.GetDepGraph(mockICTX)
 	require.NoError(t, err)
 	assert.Empty(t, result.DepGraphBytes)
-	assert.Len(t, result.ScanFailures, 1)
-	assert.Equal(t, "no supported files found", result.ScanFailures[0], "should use message only when no path")
+	assert.Len(t, result.ScanErrors, 1)
+	assert.Equal(t, service.ScanError{Subject: "", Text: "no supported files found"}, result.ScanErrors[0], "should use message only when no path")
 }
 
 func TestGetDepGraph_uvSupport(t *testing.T) {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -17,3 +17,6 @@ const FeatureFlagShowNpmScope = "internal_snyk_show_npm_scope_enabled"
 
 // ShowNpmScope is the feature flag name for the npm build scope feature.
 const ShowNpmScope = "show-npm-scope"
+
+// AllowIncompleteSBOM is the analytics key for the allow-incomplete-sbom CLI flag.
+const AllowIncompleteSBOM = "allow-incomplete-sbom"

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -8,6 +8,7 @@ const (
 	FlagFile                         = "file"
 	FlagFormat                       = "format"
 	FlagAllProjects                  = "all-projects"
+	FlagAllowIncompleteSBOM          = "allow-incomplete-sbom"
 	FlagDetectionDepth               = "detection-depth"
 	FlagPruneRepeatedSubDependencies = "prune-repeated-subdependencies"
 	FlagExclude                      = "exclude"
@@ -54,6 +55,7 @@ func GetSBOMCreateFlagSet() *pflag.FlagSet {
 	flagSet.Bool(FlagExperimental, false, "Deprecated. Will be ignored.")
 	flagSet.Bool(FlagUnmanaged, false, "For C/C++ only, scan all files for known open source dependencies and build an SBOM.")
 	flagSet.Bool(FlagAllProjects, false, "Auto-detect all projects in the working directory (including Yarn workspaces).")
+	flagSet.Bool(FlagAllowIncompleteSBOM, false, "When used with --all-projects, continue generating the SBOM even if some projects fail to resolve.")
 	flagSet.Bool(FlagYarnWorkspaces, false, "Detect and scan Yarn Workspaces only when a lockfile is in the root.")
 	flagSet.String(FlagExclude, "", "Can be used with --all-projects to indicate directory names and file names to exclude. Must be comma separated.")
 	flagSet.String(FlagDetectionDepth, "", "Use with --all-projects to indicate how many subdirectories to search. "+

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -32,6 +32,11 @@ func TestGetSBOMExportFlagSet(t *testing.T) {
 			expected: false,
 		},
 		{
+			flagName: FlagAllowIncompleteSBOM,
+			isBool:   true,
+			expected: false,
+		},
+		{
 			flagName: FlagExclude,
 			isBool:   false,
 			expected: "",

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -67,8 +67,6 @@ func DepGraphsToSBOM(
 		return nil, errFactory.NewFatalSBOMGenerationError(err)
 	}
 
-	apiURL = "http://localhost:8080"
-
 	req, err := http.NewRequestWithContext(
 		context.Background(),
 		http.MethodPost,
@@ -147,15 +145,6 @@ func ValidateSBOMFormat(errFactory *errors.ErrorFactory, candidate string) error
 func preparePayload(depGraphs []json.RawMessage, scanErrors []ScanError, subject *Subject, t *Tool) ([]byte, error) {
 	// by using json.RawMessage everywhere we expect a json-encoded []byte, we can embed this
 	// directly in Go types and call `json.Marshal` on it to embed the JSON directly.
-
-	// All projects failed — send only subject + scanErrors, no dep-graphs field at all.
-	if len(depGraphs) == 0 && len(scanErrors) > 0 {
-		return json.Marshal(&payloadScanErrorsOnly{
-			Tools:      []*Tool{t},
-			Subject:    subject,
-			ScanErrors: scanErrors,
-		})
-	}
 
 	// only send the request with a single depGraph if there's no subject. If there is a subject, we
 	// want to use the multi-depgraph-endpoint so that we can overwrite the depGraph's name &

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -54,7 +54,7 @@ func DepGraphsToSBOM(
 	apiURL string,
 	orgID string,
 	depGraphs []json.RawMessage,
-	scanFailures []string,
+	scanErrors []ScanError,
 	subject *Subject,
 	t *Tool,
 	format string,
@@ -62,10 +62,12 @@ func DepGraphsToSBOM(
 	logger *zerolog.Logger,
 	errFactory *errors.ErrorFactory,
 ) (result *SBOMResult, err error) {
-	payload, err := preparePayload(depGraphs, scanFailures, subject, t)
+	payload, err := preparePayload(depGraphs, scanErrors, subject, t)
 	if err != nil {
 		return nil, errFactory.NewFatalSBOMGenerationError(err)
 	}
+
+	apiURL = "http://localhost:8080"
 
 	req, err := http.NewRequestWithContext(
 		context.Background(),
@@ -142,9 +144,18 @@ func ValidateSBOMFormat(errFactory *errors.ErrorFactory, candidate string) error
 	return errFactory.NewInvalidFormatError(candidate, sbomFormats[:])
 }
 
-func preparePayload(depGraphs []json.RawMessage, scanFailures []string, subject *Subject, t *Tool) ([]byte, error) {
+func preparePayload(depGraphs []json.RawMessage, scanErrors []ScanError, subject *Subject, t *Tool) ([]byte, error) {
 	// by using json.RawMessage everywhere we expect a json-encoded []byte, we can embed this
 	// directly in Go types and call `json.Marshal` on it to embed the JSON directly.
+
+	// All projects failed — send only subject + scanErrors, no dep-graphs field at all.
+	if len(depGraphs) == 0 && len(scanErrors) > 0 {
+		return json.Marshal(&payloadScanErrorsOnly{
+			Tools:      []*Tool{t},
+			Subject:    subject,
+			ScanErrors: scanErrors,
+		})
+	}
 
 	// only send the request with a single depGraph if there's no subject. If there is a subject, we
 	// want to use the multi-depgraph-endpoint so that we can overwrite the depGraph's name &
@@ -161,9 +172,9 @@ func preparePayload(depGraphs []json.RawMessage, scanFailures []string, subject 
 	}
 
 	return json.Marshal(&payloadMultipleDepGraphs{
-		Tools:        []*Tool{t},
-		DepGraphs:    depGraphs,
-		ScanFailures: scanFailures,
-		Subject:      subject,
+		Tools:      []*Tool{t},
+		DepGraphs:  depGraphs,
+		ScanErrors: scanErrors,
+		Subject:    subject,
 	})
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -54,6 +54,7 @@ func DepGraphsToSBOM(
 	apiURL string,
 	orgID string,
 	depGraphs []json.RawMessage,
+	scanFailures []string,
 	subject *Subject,
 	t *Tool,
 	format string,
@@ -61,7 +62,7 @@ func DepGraphsToSBOM(
 	logger *zerolog.Logger,
 	errFactory *errors.ErrorFactory,
 ) (result *SBOMResult, err error) {
-	payload, err := preparePayload(depGraphs, subject, t)
+	payload, err := preparePayload(depGraphs, scanFailures, subject, t)
 	if err != nil {
 		return nil, errFactory.NewFatalSBOMGenerationError(err)
 	}
@@ -141,7 +142,7 @@ func ValidateSBOMFormat(errFactory *errors.ErrorFactory, candidate string) error
 	return errFactory.NewInvalidFormatError(candidate, sbomFormats[:])
 }
 
-func preparePayload(depGraphs []json.RawMessage, subject *Subject, t *Tool) ([]byte, error) {
+func preparePayload(depGraphs []json.RawMessage, scanFailures []string, subject *Subject, t *Tool) ([]byte, error) {
 	// by using json.RawMessage everywhere we expect a json-encoded []byte, we can embed this
 	// directly in Go types and call `json.Marshal` on it to embed the JSON directly.
 
@@ -160,8 +161,9 @@ func preparePayload(depGraphs []json.RawMessage, subject *Subject, t *Tool) ([]b
 	}
 
 	return json.Marshal(&payloadMultipleDepGraphs{
-		Tools:     []*Tool{t},
-		DepGraphs: depGraphs,
-		Subject:   subject,
+		Tools:        []*Tool{t},
+		DepGraphs:    depGraphs,
+		ScanFailures: scanFailures,
+		Subject:      subject,
 	})
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -62,8 +62,9 @@ func TestDepGraphsToSBOM(t *testing.T) {
 				mockSBOMService.URL,
 				orgID,
 				[]json.RawMessage{[]byte("{}")},
-				nil,
-				nil,
+				nil, // scanFailures
+				nil, // subject
+				nil, // tool
 				tt.format,
 				false,
 				&logger,
@@ -97,8 +98,9 @@ func TestDepGraphsToSBOM_GoModuleLevel(t *testing.T) {
 		mockSBOMService.URL,
 		orgID,
 		[]json.RawMessage{[]byte("{}")},
-		nil,
-		nil,
+		nil, // scanFailures
+		nil, // subject
+		nil, // tool
 		format,
 		true,
 		&logger,
@@ -133,6 +135,7 @@ func TestDepGraphsToSBOM_MultipleDepGraphs(t *testing.T) {
 		mockSBOMService.URL,
 		orgID,
 		depGraphs,
+		nil, // scanFailures
 		subject,
 		tool,
 		format,
@@ -167,6 +170,7 @@ func TestDepGraphsToSBOM_SingleDepGraph_WithSubject(t *testing.T) {
 		mockSBOMService.URL,
 		orgID,
 		depGraphs,
+		nil, // scanFailures
 		subject,
 		tool,
 		format,
@@ -193,8 +197,9 @@ func TestDepGraphsToSBOM_FailedRequest(t *testing.T) {
 		serverURL,
 		orgID,
 		[]json.RawMessage{[]byte("{}")},
-		nil,
-		nil,
+		nil, // scanFailures
+		nil, // subject
+		nil, // tool
 		"cyclonedx1.4+json",
 		false,
 		&logger,
@@ -246,8 +251,9 @@ func TestDepGraphsToSBOM_UnsuccessfulResponse(t *testing.T) {
 				mockSBOMService.URL,
 				orgID,
 				[]json.RawMessage{[]byte("{}")},
-				nil,
-				nil,
+				nil, // scanFailures
+				nil, // subject
+				nil, // tool
 				"cyclonedx1.4+json",
 				false,
 				&logger,

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -265,6 +265,94 @@ func TestDepGraphsToSBOM_UnsuccessfulResponse(t *testing.T) {
 	}
 }
 
+func TestDepGraphsToSBOM_WithScanErrors_PartialSuccess(t *testing.T) {
+	format := "cyclonedx1.4+json"
+	expectedContentType := "application/vnd.cyclonedx+json"
+	mockBody := []byte("{}")
+	response := mocks.NewMockResponse(expectedContentType, mockBody, http.StatusOK)
+	mockSBOMService := mocks.NewMockSBOMService(response, func(r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		defer r.Body.Close() //nolint:errcheck // Test cleanup, error can be safely ignored
+		require.NoError(t, err)
+		assert.JSONEq(t,
+			`{"depGraphs":[{"pkgManager":{"name":"npm"}}],`+
+				`"scanErrors":[{"subject":"project2/pom.xml","text":"missing lockfile"}],`+
+				`"subject":{"name":"my-repo","version":"1.0.0"},`+
+				`"tools":[{"name":"snyk-cli","vendor":"Snyk","version":"1.2.3"}]}`,
+			string(body))
+	})
+	logger := zerolog.New(&bytes.Buffer{})
+	errFactory := errors.NewErrorFactory(&logger)
+	depGraphs := []json.RawMessage{[]byte(`{"pkgManager":{"name":"npm"}}`)}
+	scanErrors := []ScanError{{Subject: "project2/pom.xml", Text: "missing lockfile"}}
+	subject := NewSubject("my-repo", "1.0.0")
+	tool := &Tool{Vendor: "Snyk", Name: "snyk-cli", Version: "1.2.3"}
+
+	res, err := DepGraphsToSBOM(
+		http.DefaultClient,
+		mockSBOMService.URL,
+		orgID,
+		depGraphs,
+		scanErrors,
+		subject,
+		tool,
+		format,
+		false,
+		&logger,
+		errFactory,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, mockBody, res.Doc)
+	assert.Equal(t, expectedContentType, res.MIMEType)
+}
+
+func TestDepGraphsToSBOM_WithScanErrors_AllErrors(t *testing.T) {
+	format := "cyclonedx1.4+json"
+	expectedContentType := "application/vnd.cyclonedx+json"
+	mockBody := []byte("{}")
+	response := mocks.NewMockResponse(expectedContentType, mockBody, http.StatusOK)
+	mockSBOMService := mocks.NewMockSBOMService(response, func(r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		defer r.Body.Close() //nolint:errcheck // Test cleanup, error can be safely ignored
+		require.NoError(t, err)
+		assert.JSONEq(t,
+			`{"depGraphs":[],`+
+				`"scanErrors":[`+
+				`{"subject":"project1/package.json","text":"missing lockfile"},`+
+				`{"subject":"project2/pom.xml","text":"invalid POM"}`+
+				`],`+
+				`"subject":{"name":"my-repo","version":"1.0.0"},`+
+				`"tools":[{"name":"snyk-cli","vendor":"Snyk","version":"1.2.3"}]}`,
+			string(body))
+	})
+	logger := zerolog.New(&bytes.Buffer{})
+	errFactory := errors.NewErrorFactory(&logger)
+	depGraphs := []json.RawMessage{}
+	scanErrors := []ScanError{
+		{Subject: "project1/package.json", Text: "missing lockfile"},
+		{Subject: "project2/pom.xml", Text: "invalid POM"},
+	}
+	subject := NewSubject("my-repo", "1.0.0")
+	tool := &Tool{Vendor: "Snyk", Name: "snyk-cli", Version: "1.2.3"}
+
+	res, err := DepGraphsToSBOM(
+		http.DefaultClient,
+		mockSBOMService.URL,
+		orgID,
+		depGraphs,
+		scanErrors,
+		subject,
+		tool,
+		format,
+		false,
+		&logger,
+		errFactory,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, mockBody, res.Doc)
+	assert.Equal(t, expectedContentType, res.MIMEType)
+}
+
 func TestValidateSBOMFormat_EmptyFormat(t *testing.T) {
 	logger := zerolog.New(&bytes.Buffer{})
 	errFactory := errors.NewErrorFactory(&logger)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -62,7 +62,7 @@ func TestDepGraphsToSBOM(t *testing.T) {
 				mockSBOMService.URL,
 				orgID,
 				[]json.RawMessage{[]byte("{}")},
-				nil, // scanFailures
+				nil, // scanErrors
 				nil, // subject
 				nil, // tool
 				tt.format,
@@ -98,7 +98,7 @@ func TestDepGraphsToSBOM_GoModuleLevel(t *testing.T) {
 		mockSBOMService.URL,
 		orgID,
 		[]json.RawMessage{[]byte("{}")},
-		nil, // scanFailures
+		nil, // scanErrors
 		nil, // subject
 		nil, // tool
 		format,
@@ -135,7 +135,7 @@ func TestDepGraphsToSBOM_MultipleDepGraphs(t *testing.T) {
 		mockSBOMService.URL,
 		orgID,
 		depGraphs,
-		nil, // scanFailures
+		nil, // scanErrors
 		subject,
 		tool,
 		format,
@@ -170,7 +170,7 @@ func TestDepGraphsToSBOM_SingleDepGraph_WithSubject(t *testing.T) {
 		mockSBOMService.URL,
 		orgID,
 		depGraphs,
-		nil, // scanFailures
+		nil, // scanErrors
 		subject,
 		tool,
 		format,
@@ -197,7 +197,7 @@ func TestDepGraphsToSBOM_FailedRequest(t *testing.T) {
 		serverURL,
 		orgID,
 		[]json.RawMessage{[]byte("{}")},
-		nil, // scanFailures
+		nil, // scanErrors
 		nil, // subject
 		nil, // tool
 		"cyclonedx1.4+json",
@@ -251,7 +251,7 @@ func TestDepGraphsToSBOM_UnsuccessfulResponse(t *testing.T) {
 				mockSBOMService.URL,
 				orgID,
 				[]json.RawMessage{[]byte("{}")},
-				nil, // scanFailures
+				nil, // scanErrors
 				nil, // subject
 				nil, // tool
 				"cyclonedx1.4+json",

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -8,14 +8,27 @@ type Tool struct {
 	Version string `json:"version"`
 }
 
+type ScanError struct {
+	Subject string `json:"subject,omitempty"`
+	Text    string `json:"text"`
+}
+
 type payloadSingleDepGraph struct {
 	Tools    []*Tool         `json:"tools,omitempty"`
 	DepGraph json.RawMessage `json:"depGraph"`
 }
 
 type payloadMultipleDepGraphs struct {
-	Tools        []*Tool           `json:"tools,omitempty"`
-	DepGraphs    []json.RawMessage `json:"depGraphs"`
-	Subject      *Subject          `json:"subject"`
-	ScanFailures []string          `json:"scanFailures,omitempty"`
+	Tools      []*Tool           `json:"tools,omitempty"`
+	DepGraphs  []json.RawMessage `json:"depGraphs"`
+	Subject    *Subject          `json:"subject"`
+	ScanErrors []ScanError       `json:"scanErrors,omitempty"`
+}
+
+// payloadScanErrorsOnly is used when all projects failed to scan —
+// no dep-graphs are available, only scan errors and the root subject.
+type payloadScanErrorsOnly struct {
+	Tools      []*Tool     `json:"tools,omitempty"`
+	Subject    *Subject    `json:"subject"`
+	ScanErrors []ScanError `json:"scanErrors"`
 }

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -14,7 +14,8 @@ type payloadSingleDepGraph struct {
 }
 
 type payloadMultipleDepGraphs struct {
-	Tools     []*Tool           `json:"tools,omitempty"`
-	DepGraphs []json.RawMessage `json:"depGraphs"`
-	Subject   *Subject          `json:"subject"`
+	Tools        []*Tool           `json:"tools,omitempty"`
+	DepGraphs    []json.RawMessage `json:"depGraphs"`
+	Subject      *Subject          `json:"subject"`
+	ScanFailures []string          `json:"scanFailures,omitempty"`
 }

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -25,10 +25,3 @@ type payloadMultipleDepGraphs struct {
 	ScanErrors []ScanError       `json:"scanErrors,omitempty"`
 }
 
-// payloadScanErrorsOnly is used when all projects failed to scan —
-// no dep-graphs are available, only scan errors and the root subject.
-type payloadScanErrorsOnly struct {
-	Tools      []*Tool     `json:"tools,omitempty"`
-	Subject    *Subject    `json:"subject"`
-	ScanErrors []ScanError `json:"scanErrors"`
-}

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -24,4 +24,3 @@ type payloadMultipleDepGraphs struct {
 	Subject    *Subject          `json:"subject"`
 	ScanErrors []ScanError       `json:"scanErrors,omitempty"`
 }
-


### PR DESCRIPTION
Adds --allow-incomplete-sbom flag support for partial/empty SBOM generation. By ensuring we use the right args for the legacyCLI and parse the errors from the response into a scanError array.

We created a struct to store each scanError which contains a subject and the error detail. We then maintain a list of these errors per scan (single and multi plugin routes) .
We extend the depGraph result struct to include this scanError array which we then include in the payload for the sbom generation request.
Both the scanError and depGraph fields can either be empty or nil.
