### PR TITLE
feat: track allow-incomplete-sbom flag usage in analytics [CSENG-177]

### DIFF
--- a/internal/commands/sbomcreate/sbomcreate.go
+++ b/internal/commands/sbomcreate/sbomcreate.go
@@ -59,6 +59,7 @@ func SBOMWorkflow(
 	ai := ictx.GetAnalytics()
 	ai.AddExtensionBoolValue(constants.ShowMavenBuildScope, config.GetBool(constants.FeatureFlagShowMavenBuildScope))
 	ai.AddExtensionBoolValue(constants.ShowNpmScope, config.GetBool(constants.FeatureFlagShowNpmScope))
+	ai.AddExtensionBoolValue(constants.AllowIncompleteSBOM, config.GetBool(flags.FlagAllowIncompleteSBOM))
 
 	depGraphResult, err := GetDepGraph(ictx)
 	if err != nil {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -17,3 +17,6 @@ const FeatureFlagShowNpmScope = "internal_snyk_show_npm_scope_enabled"
 
 // ShowNpmScope is the feature flag name for the npm build scope feature.
 const ShowNpmScope = "show-npm-scope"
+
+// AllowIncompleteSBOM is the analytics key for the allow-incomplete-sbom CLI flag.
+const AllowIncompleteSBOM = "allow-incomplete-sbom"


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable) — no breaking changes
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Adds observability for the `--allow-incomplete-sbom` CLI flag by sending its value to the Snyk analytics pipeline, which is forwarded to Datadog.

Previously, when a user invoked `snyk sbom` with `--allow-incomplete-sbom`, the flag's usage was invisible in our telemetry. This made it impossible to track adoption, validate rollout success, or correlate the flag with SBOM generation outcomes in Datadog dashboards.

## Where should the reviewer start?

Start with `internal/commands/sbomcreate/sbomcreate.go` at the `SBOMWorkflow` function (lines 59–62). The new line follows the identical pattern already established for `show-maven-build-scope` and `show-npm-scope`. Then verify the new constant in `internal/constants/constants.go`.

## How should this be manually tested?

1. Build the CLI with this extension version.
2. Run `snyk sbom --format cyclonedx1.4+json --allow-incomplete-sbom` against a multi-project workspace.
3. Inspect the analytics payload (e.g. via a local proxy or debug logging) and confirm a field `allow-incomplete-sbom: true` is present in the extension data.
4. Run the same command **without** `--allow-incomplete-sbom` and confirm the field appears as `allow-incomplete-sbom: false`.

## What's the product update that needs to be communicated to CLI users?

No user-facing behavior changes. This is an internal observability improvement only. The `--allow-incomplete-sbom` flag continues to work exactly as before; its value is now also reported in CLI telemetry.

## Risk assessment

**Low.** The change is purely additive — one new constant and one additional call to an existing analytics API (`AddExtensionBoolValue`). There is no modification to the SBOM generation logic, no new dependencies, and no impact on the CLI's output or error handling. The analytics call is fire-and-forget and does not affect workflow success or failure.

## Any background context

The Snyk analytics pipeline serializes extension values added via `AddExtensionBoolValue` / `AddExtensionStringValue` / `AddExtensionIntegerValue` into the instrumentation payload, which is then forwarded to Datadog. This same pattern is already used for `show-maven-build-scope` and `show-npm-scope` flags within the same workflow.
