### PR TITLE
fix: set force-single-graph for SBOM create to prevent duplicate components

### DIFF
--- a/internal/commands/sbomcreate/depgraph.go
+++ b/internal/commands/sbomcreate/depgraph.go
@@ -49,6 +49,7 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 	}
 	if useSCAPlugins {
 		depGraphConfig.Set("use-sbom-resolution", true)
+		depGraphConfig.Set("force-single-graph", true)
 	}
 
 	depGraphs, err := engine.InvokeWithConfig(DepGraphWorkflowID, depGraphConfig)


### PR DESCRIPTION
### What this does

Sets `force-single-graph=true` when fetching dep-graphs via the new SBOM resolution path. This prevents workspace members from being split into separate dep-graphs within the same ecosystem, which was causing duplicated components in the generated SBOM.

This depends on the change [here](https://github.com/snyk/cli-extension-dep-graph/pull/133) in the dep-graph extension.