### PR TITLE
feat: add new --allow-incomplete-sbom-flag [CSENG-175]

### DIFF
--- a/internal/commands/sbomcreate/depgraph.go
+++ b/internal/commands/sbomcreate/depgraph.go
@@ -35,13 +35,13 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 
 	depGraphConfig := config.Clone()
 	if config.GetBool(flags.FlagAllProjects) {
-		allowIncomplete := config.GetBool(flags.FlagAllowIncompleteSBOM)
-		if allowIncomplete {
-			depGraphConfig.Set("fail-fast", false)
-			depGraphConfig.Set("print-output-jsonl-with-errors", true)
-		} else {
-			depGraphConfig.Set("fail-fast", true)
-		}
+		depGraphConfig.Set("fail-fast", true)
+	}
+
+	allowIncomplete := config.GetBool(flags.FlagAllowIncompleteSBOM)
+	if allowIncomplete {
+		depGraphConfig.Set("fail-fast", false)
+		depGraphConfig.Set("print-output-jsonl-with-errors", true)
 	}
 
 	// Currently, we don't support dotnet runtime resolution for SBOMs.

--- a/internal/commands/sbomcreate/depgraph.go
+++ b/internal/commands/sbomcreate/depgraph.go
@@ -13,6 +13,7 @@ import (
 	"github.com/snyk/cli-extension-sbom/internal/constants"
 	"github.com/snyk/cli-extension-sbom/internal/errors"
 	"github.com/snyk/cli-extension-sbom/internal/flags"
+	"github.com/snyk/cli-extension-sbom/internal/service"
 	"github.com/snyk/cli-extension-sbom/internal/util"
 )
 
@@ -21,6 +22,7 @@ var DepGraphWorkflowID = workflow.NewWorkflowIdentifier("depgraph")
 type DepGraphResult struct {
 	Name          string
 	DepGraphBytes []json.RawMessage
+	ScanErrors    []service.ScanError
 }
 
 func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
@@ -33,7 +35,13 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 
 	depGraphConfig := config.Clone()
 	if config.GetBool(flags.FlagAllProjects) {
-		depGraphConfig.Set("fail-fast", true)
+		allowIncomplete := config.GetBool(flags.FlagAllowIncompleteSBOM)
+		if allowIncomplete {
+			depGraphConfig.Set("fail-fast", false)
+			depGraphConfig.Set("print-output-jsonl-with-errors", true)
+		} else {
+			depGraphConfig.Set("fail-fast", true)
+		}
 	}
 
 	// Currently, we don't support dotnet runtime resolution for SBOMs.
@@ -54,17 +62,31 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 		return nil, errFactory.NewDepGraphWorkflowError(err)
 	}
 
-	numGraphs := len(depGraphs)
-	logger.Printf("Generating documents for %d depgraph(s)\n", numGraphs)
-	depGraphsBytes := make([]json.RawMessage, numGraphs)
-	for i, depGraph := range depGraphs {
+	depGraphsBytes := make([]json.RawMessage, 0, len(depGraphs))
+	var scanErrors []service.ScanError
+	for _, depGraph := range depGraphs {
+		if errList := depGraph.GetErrorList(); len(errList) > 0 {
+			subject := depGraph.GetContentLocation()
+			for i := range errList {
+				e := &errList[i]
+				msg := e.Detail
+				if msg == "" {
+					msg = e.Title
+				}
+				scanErrors = append(scanErrors, service.ScanError{Subject: subject, Text: msg})
+			}
+			continue
+		}
 		depGraphBytes, err := getPayloadBytes(depGraph)
 		if err != nil {
 			return nil, errFactory.NewDepGraphWorkflowError(err)
 		}
-		depGraphsBytes[i] = depGraphBytes
+		depGraphsBytes = append(depGraphsBytes, depGraphBytes)
 	}
-	if numGraphs > 1 {
+
+	numGraphs := len(depGraphsBytes)
+	logger.Printf("Generating documents for %d depgraph(s)\n", numGraphs)
+	if numGraphs != 1 || len(scanErrors) > 0 {
 		if name == "" {
 			// Fall back to current working directory
 			wd, err := os.Getwd()
@@ -79,6 +101,7 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 	return &DepGraphResult{
 		Name:          name,
 		DepGraphBytes: depGraphsBytes,
+		ScanErrors:    scanErrors,
 	}, nil
 }
 

--- a/internal/commands/sbomcreate/sbomcreate.go
+++ b/internal/commands/sbomcreate/sbomcreate.go
@@ -59,6 +59,7 @@ func SBOMWorkflow(
 	ai := ictx.GetAnalytics()
 	ai.AddExtensionBoolValue(constants.ShowMavenBuildScope, config.GetBool(constants.FeatureFlagShowMavenBuildScope))
 	ai.AddExtensionBoolValue(constants.ShowNpmScope, config.GetBool(constants.FeatureFlagShowNpmScope))
+	ai.AddExtensionBoolValue(constants.AllowIncompleteSBOM, config.GetBool(flags.FlagAllowIncompleteSBOM))
 
 	depGraphResult, err := GetDepGraph(ictx)
 	if err != nil {
@@ -72,6 +73,7 @@ func SBOMWorkflow(
 		config.GetString(configuration.API_URL),
 		orgID,
 		depGraphResult.DepGraphBytes,
+		depGraphResult.ScanErrors,
 		service.NewSubject(depGraphResult.Name, version),
 		&service.Tool{Vendor: "Snyk", Name: ri.GetName(), Version: ri.GetVersion()},
 		format,

--- a/internal/commands/sbomcreate/sbomcreate_test.go
+++ b/internal/commands/sbomcreate/sbomcreate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/rs/zerolog"
 	"github.com/snyk/error-catalog-golang-public/snyk"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 	"github.com/snyk/go-application-framework/pkg/analytics"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/mocks"
@@ -27,6 +28,7 @@ import (
 	"github.com/snyk/cli-extension-sbom/internal/constants"
 	"github.com/snyk/cli-extension-sbom/internal/flags"
 	svcmocks "github.com/snyk/cli-extension-sbom/internal/mocks"
+	"github.com/snyk/cli-extension-sbom/internal/service"
 	"github.com/snyk/cli-extension-sbom/pkg/sbom"
 )
 
@@ -306,6 +308,124 @@ func assertWorkflowExists(t *testing.T, e workflow.Engine, id *url.URL) {
 	wflw, ok := e.GetWorkflow(id)
 	assert.True(t, ok)
 	assert.NotNil(t, wflw)
+}
+
+func newDepGraphDataWithError(t *testing.T, path string, err *snyk_errors.Error) workflow.Data {
+	t.Helper()
+	d := workflow.NewData(
+		workflow.NewTypeIdentifier(sbomcreate.DepGraphWorkflowID, "cyclonedx"),
+		"application/json",
+		[]byte(`{}`),
+	)
+	impl, ok := d.(*workflow.DataImpl)
+	require.True(t, ok)
+	impl.SetContentLocation(path)
+	impl.AddError(*err)
+	return d
+}
+
+func TestGetDepGraph_PartialSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	successData := newDepGraphData(t, []byte(`{"pkgManager":{"name":"npm"}}`))
+	errorData := newDepGraphDataWithError(t, "project2/pom.xml", &snyk_errors.Error{
+		Title:  "failed to resolve",
+		Detail: "missing lockfile",
+	})
+
+	mockEngine := mocks.NewMockEngine(ctrl)
+	mockEngine.EXPECT().
+		InvokeWithConfig(gomock.Eq(sbomcreate.DepGraphWorkflowID), gomock.Any()).
+		Return([]workflow.Data{successData, errorData}, nil).
+		Times(1)
+
+	mockLogger := zerolog.New(io.Discard)
+	mockConfig := configuration.New()
+	mockConfig.Set("name", "my-repo")
+
+	mockICTX := mocks.NewMockInvocationContext(ctrl)
+	mockICTX.EXPECT().GetEngine().Return(mockEngine).AnyTimes()
+	mockICTX.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
+	mockICTX.EXPECT().GetEnhancedLogger().Return(&mockLogger).AnyTimes()
+
+	result, err := sbomcreate.GetDepGraph(mockICTX)
+	require.NoError(t, err)
+	assert.Len(t, result.DepGraphBytes, 1, "should have one successful depGraph")
+	assert.Len(t, result.ScanErrors, 1, "should have one scan failure")
+	assert.Equal(t, service.ScanError{Subject: "project2/pom.xml", Text: "missing lockfile"}, result.ScanErrors[0])
+}
+
+func TestGetDepGraph_AllErrors_EmptySBOM(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	errorData1 := newDepGraphDataWithError(t, "project1/package.json", &snyk_errors.Error{
+		Title:  "scan failed",
+		Detail: "missing lockfile",
+	})
+	errorData2 := newDepGraphDataWithError(t, "project2/pom.xml", &snyk_errors.Error{
+		Title:  "invalid POM",
+		Detail: "",
+	})
+
+	mockEngine := mocks.NewMockEngine(ctrl)
+	mockEngine.EXPECT().
+		InvokeWithConfig(gomock.Eq(sbomcreate.DepGraphWorkflowID), gomock.Any()).
+		Return([]workflow.Data{errorData1, errorData2}, nil).
+		Times(1)
+
+	mockLogger := zerolog.New(io.Discard)
+	mockConfig := configuration.New()
+	mockConfig.Set("name", "")
+
+	mockICTX := mocks.NewMockInvocationContext(ctrl)
+	mockICTX.EXPECT().GetEngine().Return(mockEngine).AnyTimes()
+	mockICTX.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
+	mockICTX.EXPECT().GetEnhancedLogger().Return(&mockLogger).AnyTimes()
+
+	result, err := sbomcreate.GetDepGraph(mockICTX)
+	require.NoError(t, err)
+	assert.Empty(t, result.DepGraphBytes, "should have zero depGraphs")
+	assert.Len(t, result.ScanErrors, 2, "should have two scan failures")
+	assert.Equal(t, service.ScanError{Subject: "project1/package.json", Text: "missing lockfile"}, result.ScanErrors[0])
+	assert.Equal(t, service.ScanError{Subject: "project2/pom.xml", Text: "invalid POM"}, result.ScanErrors[1], "should fall back to Title when Detail is empty")
+	assert.NotEmpty(t, result.Name, "should default name from working directory")
+}
+
+func TestGetDepGraph_ErrorWithoutPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	d := workflow.NewData(
+		workflow.NewTypeIdentifier(sbomcreate.DepGraphWorkflowID, "cyclonedx"),
+		"application/json",
+		[]byte(`{}`),
+	)
+	impl, ok := d.(*workflow.DataImpl)
+	require.True(t, ok)
+	impl.AddError(snyk_errors.Error{Title: "no supported files found"})
+
+	mockEngine := mocks.NewMockEngine(ctrl)
+	mockEngine.EXPECT().
+		InvokeWithConfig(gomock.Eq(sbomcreate.DepGraphWorkflowID), gomock.Any()).
+		Return([]workflow.Data{d}, nil).
+		Times(1)
+
+	mockLogger := zerolog.New(io.Discard)
+	mockConfig := configuration.New()
+	mockConfig.Set("name", "my-repo")
+
+	mockICTX := mocks.NewMockInvocationContext(ctrl)
+	mockICTX.EXPECT().GetEngine().Return(mockEngine).AnyTimes()
+	mockICTX.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
+	mockICTX.EXPECT().GetEnhancedLogger().Return(&mockLogger).AnyTimes()
+
+	result, err := sbomcreate.GetDepGraph(mockICTX)
+	require.NoError(t, err)
+	assert.Empty(t, result.DepGraphBytes)
+	assert.Len(t, result.ScanErrors, 1)
+	assert.Equal(t, service.ScanError{Subject: "", Text: "no supported files found"}, result.ScanErrors[0], "should use message only when no path")
 }
 
 func TestGetDepGraph_disablesDotnetRuntimeResolutionWhenPreviouslyEnabled(t *testing.T) {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -17,3 +17,6 @@ const FeatureFlagShowNpmScope = "internal_snyk_show_npm_scope_enabled"
 
 // ShowNpmScope is the feature flag name for the npm build scope feature.
 const ShowNpmScope = "show-npm-scope"
+
+// AllowIncompleteSBOM is the analytics key for the allow-incomplete-sbom CLI flag.
+const AllowIncompleteSBOM = "allow-incomplete-sbom"

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -8,6 +8,7 @@ const (
 	FlagFile                         = "file"
 	FlagFormat                       = "format"
 	FlagAllProjects                  = "all-projects"
+	FlagAllowIncompleteSBOM          = "allow-incomplete-sbom"
 	FlagDetectionDepth               = "detection-depth"
 	FlagPruneRepeatedSubDependencies = "prune-repeated-subdependencies"
 	FlagExclude                      = "exclude"
@@ -54,6 +55,7 @@ func GetSBOMCreateFlagSet() *pflag.FlagSet {
 	flagSet.Bool(FlagExperimental, false, "Deprecated. Will be ignored.")
 	flagSet.Bool(FlagUnmanaged, false, "For C/C++ only, scan all files for known open source dependencies and build an SBOM.")
 	flagSet.Bool(FlagAllProjects, false, "Auto-detect all projects in the working directory (including Yarn workspaces).")
+	flagSet.Bool(FlagAllowIncompleteSBOM, false, "When used with --all-projects, continue generating the SBOM even if some projects fail to resolve.")
 	flagSet.Bool(FlagYarnWorkspaces, false, "Detect and scan Yarn Workspaces only when a lockfile is in the root.")
 	flagSet.String(FlagExclude, "", "Can be used with --all-projects to indicate directory names and file names to exclude. Must be comma separated.")
 	flagSet.String(FlagDetectionDepth, "", "Use with --all-projects to indicate how many subdirectories to search. "+

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -32,6 +32,11 @@ func TestGetSBOMExportFlagSet(t *testing.T) {
 			expected: false,
 		},
 		{
+			flagName: FlagAllowIncompleteSBOM,
+			isBool:   true,
+			expected: false,
+		},
+		{
 			flagName: FlagExclude,
 			isBool:   false,
 			expected: "",

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -54,6 +54,7 @@ func DepGraphsToSBOM(
 	apiURL string,
 	orgID string,
 	depGraphs []json.RawMessage,
+	scanErrors []ScanError,
 	subject *Subject,
 	t *Tool,
 	format string,
@@ -61,7 +62,7 @@ func DepGraphsToSBOM(
 	logger *zerolog.Logger,
 	errFactory *errors.ErrorFactory,
 ) (result *SBOMResult, err error) {
-	payload, err := preparePayload(depGraphs, subject, t)
+	payload, err := preparePayload(depGraphs, scanErrors, subject, t)
 	if err != nil {
 		return nil, errFactory.NewFatalSBOMGenerationError(err)
 	}
@@ -141,7 +142,7 @@ func ValidateSBOMFormat(errFactory *errors.ErrorFactory, candidate string) error
 	return errFactory.NewInvalidFormatError(candidate, sbomFormats[:])
 }
 
-func preparePayload(depGraphs []json.RawMessage, subject *Subject, t *Tool) ([]byte, error) {
+func preparePayload(depGraphs []json.RawMessage, scanErrors []ScanError, subject *Subject, t *Tool) ([]byte, error) {
 	// by using json.RawMessage everywhere we expect a json-encoded []byte, we can embed this
 	// directly in Go types and call `json.Marshal` on it to embed the JSON directly.
 
@@ -160,8 +161,9 @@ func preparePayload(depGraphs []json.RawMessage, subject *Subject, t *Tool) ([]b
 	}
 
 	return json.Marshal(&payloadMultipleDepGraphs{
-		Tools:     []*Tool{t},
-		DepGraphs: depGraphs,
-		Subject:   subject,
+		Tools:      []*Tool{t},
+		DepGraphs:  depGraphs,
+		ScanErrors: scanErrors,
+		Subject:    subject,
 	})
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -62,8 +62,9 @@ func TestDepGraphsToSBOM(t *testing.T) {
 				mockSBOMService.URL,
 				orgID,
 				[]json.RawMessage{[]byte("{}")},
-				nil,
-				nil,
+				nil, // scanErrors
+				nil, // subject
+				nil, // tool
 				tt.format,
 				false,
 				&logger,
@@ -97,8 +98,9 @@ func TestDepGraphsToSBOM_GoModuleLevel(t *testing.T) {
 		mockSBOMService.URL,
 		orgID,
 		[]json.RawMessage{[]byte("{}")},
-		nil,
-		nil,
+		nil, // scanErrors
+		nil, // subject
+		nil, // tool
 		format,
 		true,
 		&logger,
@@ -133,6 +135,7 @@ func TestDepGraphsToSBOM_MultipleDepGraphs(t *testing.T) {
 		mockSBOMService.URL,
 		orgID,
 		depGraphs,
+		nil, // scanErrors
 		subject,
 		tool,
 		format,
@@ -167,6 +170,7 @@ func TestDepGraphsToSBOM_SingleDepGraph_WithSubject(t *testing.T) {
 		mockSBOMService.URL,
 		orgID,
 		depGraphs,
+		nil, // scanErrors
 		subject,
 		tool,
 		format,
@@ -193,8 +197,9 @@ func TestDepGraphsToSBOM_FailedRequest(t *testing.T) {
 		serverURL,
 		orgID,
 		[]json.RawMessage{[]byte("{}")},
-		nil,
-		nil,
+		nil, // scanErrors
+		nil, // subject
+		nil, // tool
 		"cyclonedx1.4+json",
 		false,
 		&logger,
@@ -246,8 +251,9 @@ func TestDepGraphsToSBOM_UnsuccessfulResponse(t *testing.T) {
 				mockSBOMService.URL,
 				orgID,
 				[]json.RawMessage{[]byte("{}")},
-				nil,
-				nil,
+				nil, // scanErrors
+				nil, // subject
+				nil, // tool
 				"cyclonedx1.4+json",
 				false,
 				&logger,
@@ -257,6 +263,94 @@ func TestDepGraphsToSBOM_UnsuccessfulResponse(t *testing.T) {
 			assert.ErrorContains(t, err, tt.expectedErr)
 		})
 	}
+}
+
+func TestDepGraphsToSBOM_WithScanErrors_PartialSuccess(t *testing.T) {
+	format := "cyclonedx1.4+json"
+	expectedContentType := "application/vnd.cyclonedx+json"
+	mockBody := []byte("{}")
+	response := mocks.NewMockResponse(expectedContentType, mockBody, http.StatusOK)
+	mockSBOMService := mocks.NewMockSBOMService(response, func(r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		defer r.Body.Close() //nolint:errcheck // Test cleanup, error can be safely ignored
+		require.NoError(t, err)
+		assert.JSONEq(t,
+			`{"depGraphs":[{"pkgManager":{"name":"npm"}}],`+
+				`"scanErrors":[{"subject":"project2/pom.xml","text":"missing lockfile"}],`+
+				`"subject":{"name":"my-repo","version":"1.0.0"},`+
+				`"tools":[{"name":"snyk-cli","vendor":"Snyk","version":"1.2.3"}]}`,
+			string(body))
+	})
+	logger := zerolog.New(&bytes.Buffer{})
+	errFactory := errors.NewErrorFactory(&logger)
+	depGraphs := []json.RawMessage{[]byte(`{"pkgManager":{"name":"npm"}}`)}
+	scanErrors := []ScanError{{Subject: "project2/pom.xml", Text: "missing lockfile"}}
+	subject := NewSubject("my-repo", "1.0.0")
+	tool := &Tool{Vendor: "Snyk", Name: "snyk-cli", Version: "1.2.3"}
+
+	res, err := DepGraphsToSBOM(
+		http.DefaultClient,
+		mockSBOMService.URL,
+		orgID,
+		depGraphs,
+		scanErrors,
+		subject,
+		tool,
+		format,
+		false,
+		&logger,
+		errFactory,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, mockBody, res.Doc)
+	assert.Equal(t, expectedContentType, res.MIMEType)
+}
+
+func TestDepGraphsToSBOM_WithScanErrors_AllErrors(t *testing.T) {
+	format := "cyclonedx1.4+json"
+	expectedContentType := "application/vnd.cyclonedx+json"
+	mockBody := []byte("{}")
+	response := mocks.NewMockResponse(expectedContentType, mockBody, http.StatusOK)
+	mockSBOMService := mocks.NewMockSBOMService(response, func(r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		defer r.Body.Close() //nolint:errcheck // Test cleanup, error can be safely ignored
+		require.NoError(t, err)
+		assert.JSONEq(t,
+			`{"depGraphs":[],`+
+				`"scanErrors":[`+
+				`{"subject":"project1/package.json","text":"missing lockfile"},`+
+				`{"subject":"project2/pom.xml","text":"invalid POM"}`+
+				`],`+
+				`"subject":{"name":"my-repo","version":"1.0.0"},`+
+				`"tools":[{"name":"snyk-cli","vendor":"Snyk","version":"1.2.3"}]}`,
+			string(body))
+	})
+	logger := zerolog.New(&bytes.Buffer{})
+	errFactory := errors.NewErrorFactory(&logger)
+	depGraphs := []json.RawMessage{}
+	scanErrors := []ScanError{
+		{Subject: "project1/package.json", Text: "missing lockfile"},
+		{Subject: "project2/pom.xml", Text: "invalid POM"},
+	}
+	subject := NewSubject("my-repo", "1.0.0")
+	tool := &Tool{Vendor: "Snyk", Name: "snyk-cli", Version: "1.2.3"}
+
+	res, err := DepGraphsToSBOM(
+		http.DefaultClient,
+		mockSBOMService.URL,
+		orgID,
+		depGraphs,
+		scanErrors,
+		subject,
+		tool,
+		format,
+		false,
+		&logger,
+		errFactory,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, mockBody, res.Doc)
+	assert.Equal(t, expectedContentType, res.MIMEType)
 }
 
 func TestValidateSBOMFormat_EmptyFormat(t *testing.T) {

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -8,13 +8,19 @@ type Tool struct {
 	Version string `json:"version"`
 }
 
+type ScanError struct {
+	Subject string `json:"subject,omitempty"`
+	Text    string `json:"text"`
+}
+
 type payloadSingleDepGraph struct {
 	Tools    []*Tool         `json:"tools,omitempty"`
 	DepGraph json.RawMessage `json:"depGraph"`
 }
 
 type payloadMultipleDepGraphs struct {
-	Tools     []*Tool           `json:"tools,omitempty"`
-	DepGraphs []json.RawMessage `json:"depGraphs"`
-	Subject   *Subject          `json:"subject"`
+	Tools      []*Tool           `json:"tools,omitempty"`
+	DepGraphs  []json.RawMessage `json:"depGraphs"`
+	Subject    *Subject          `json:"subject"`
+	ScanErrors []ScanError       `json:"scanErrors,omitempty"`
 }


### PR DESCRIPTION
## Checklist

- [x] Tests written and linted
- [ ] Documentation written
- [x] Commit history is tidy

---

## What this does

When running `snyk sbom --all-projects`, the CLI previously used `fail-fast` mode: if **any** project in the workspace failed to resolve (e.g. missing lockfile, unsupported manifest), the entire SBOM generation was aborted and no output was produced.

This PR introduces the `--allow-incomplete-sbom` flag that lets users opt in to a **partial-success** mode. When the flag is set alongside `--all-projects`:

- Projects that resolve successfully are included in the generated SBOM.
- Projects that fail are collected as structured `ScanError` entries (with a `subject` path and human-readable `text` message) and forwarded to the SBOM service alongside the successful dep-graphs.

## References
https://docs.google.com/document/d/1vhRKlienHz1kbrCI-2BJ3maO6ykmlAz-hSApgo8MGEw/edit
https://docs.google.com/document/d/1i4exfAq3Dvoy_mKwQAwL3LYE6_Qkt7jQVYVOSzijZdw/edit
https://docs.google.com/document/d/1j0gNbzCALFF3WfIxLd5PVBtglJb4kYGQdheoM27VMaY/edit