### PR TITLE
feat: route dragonfly sbom monitor flow

### DIFF
--- a/internal/commands/sbommonitor/sbommonitor.go
+++ b/internal/commands/sbommonitor/sbommonitor.go
@@ -18,10 +18,16 @@ import (
 	view "github.com/snyk/cli-extension-sbom/internal/view/sbommonitor"
 )
 
-var WorkflowID = workflow.NewWorkflowIdentifier("sbom.monitor")
-var WorkflowDataID = workflow.NewTypeIdentifier(WorkflowID, "sbom.monitor")
+var (
+	WorkflowID               = workflow.NewWorkflowIdentifier("sbom.monitor")
+	WorkflowDataID           = workflow.NewTypeIdentifier(WorkflowID, "sbom.monitor")
+	OsFlowsMonitorWorkflowID = workflow.NewWorkflowIdentifier("monitor")
+)
 
-const FeatureFlagSBOMMonitor = "feature_flag_sbom_monitor"
+const (
+	FeatureFlagSBOMMonitor     = "feature_flag_sbom_monitor"
+	FeatureFlagDflySbomMonitor = "internal_snyk_cli_rollout_dfly_sbom_monitor"
+)
 
 func RegisterWorkflows(e workflow.Engine) error {
 	sbomFlagset := flags.GetSBOMMonitorFlagSet()
@@ -33,6 +39,10 @@ func RegisterWorkflows(e workflow.Engine) error {
 	}
 
 	config_utils.AddFeatureFlagToConfig(e, FeatureFlagSBOMMonitor, "sbomMonitorBeta")
+
+	config_utils.AddFeatureFlagsToConfig(e, map[string]string{
+		FeatureFlagDflySbomMonitor: "rollout-dfly-sbom-monitor",
+	})
 
 	return nil
 }
@@ -65,6 +75,20 @@ func MonitorWorkflowWithDI(
 		return nil, errFactory.NewMissingExperimentalFlagError()
 	}
 
+	if filename == "" {
+		return nil, errFactory.NewMissingFilenameFlagError()
+	}
+
+	if config.GetBool(FeatureFlagDflySbomMonitor) {
+		logger.Println("Dragonfly SBOM monitor rollout enabled, delegating to os-flows monitor workflow")
+
+		engine := ictx.GetEngine()
+		osFlowsMonitorConfig := config.Clone()
+		osFlowsMonitorConfig.Set(flags.FlagSBOM, filename)
+
+		return engine.InvokeWithConfig(OsFlowsMonitorWorkflowID, osFlowsMonitorConfig)
+	}
+
 	// Check if the feature can be used
 	if !config.GetBool(FeatureFlagSBOMMonitor) {
 		return nil, errFactory.NewFeatureNotPermittedError(FeatureFlagSBOMMonitor)
@@ -78,10 +102,6 @@ func MonitorWorkflowWithDI(
 
 	if remoteRepoURL == "" {
 		remoteRepoURL = remoteRepoUrlGetter.GetRemoteOriginURL()
-	}
-
-	if filename == "" {
-		return nil, errFactory.NewMissingFilenameFlagError()
 	}
 
 	logger.Println("Target file:", filename)

--- a/internal/commands/sbommonitor/sbommonitor_test.go
+++ b/internal/commands/sbommonitor/sbommonitor_test.go
@@ -49,6 +49,76 @@ func TestSBOMMonitorWorkflow_NoExperimentalFlag(t *testing.T) {
 	assert.ErrorContains(t, err, "Flag `--experimental` is required to execute this command.")
 }
 
+func TestSBOMMonitorWorkflow_DflyRollout_DelegatesToOSFlows(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockEngine := mocks.NewMockEngine(ctrl)
+
+	mockICTX := mockInvocationContext(t, ctrl, "", mockEngine)
+	mockICTX.GetConfiguration().Set(flags.FlagExperimental, true)
+	mockICTX.GetConfiguration().Set(sbommonitor.FeatureFlagSBOMMonitor, true)
+	mockICTX.GetConfiguration().Set(sbommonitor.FeatureFlagDflySbomMonitor, true)
+	mockICTX.GetConfiguration().Set(flags.FlagFile, "testdata/bom.json")
+	mockICTX.GetConfiguration().Set(flags.FlagTargetReference, "main")
+
+	osFlowsConfig := mockICTX.GetConfiguration().Clone()
+	osFlowsConfig.Set(flags.FlagSBOM, "testdata/bom.json")
+
+	mockEngine.EXPECT().InvokeWithConfig(sbommonitor.OsFlowsMonitorWorkflowID, osFlowsConfig).Return([]workflow.Data{}, nil).Times(1)
+
+	result, err := sbommonitor.MonitorWorkflow(mockICTX, []workflow.Data{})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestSBOMMonitorWorkflow_DflyRollout_ForwardsProjectAttributes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockEngine := mocks.NewMockEngine(ctrl)
+
+	mockICTX := mockInvocationContext(t, ctrl, "", mockEngine)
+	mockICTX.GetConfiguration().Set(flags.FlagExperimental, true)
+	mockICTX.GetConfiguration().Set(sbommonitor.FeatureFlagSBOMMonitor, true)
+	mockICTX.GetConfiguration().Set(sbommonitor.FeatureFlagDflySbomMonitor, true)
+	mockICTX.GetConfiguration().Set(flags.FlagFile, "testdata/bom.json")
+	mockICTX.GetConfiguration().Set(flags.FlagProjectBusinessCriticality, "critical")
+	mockICTX.GetConfiguration().Set(flags.FlagProjectEnvironment, "production")
+	mockICTX.GetConfiguration().Set(flags.FlagProjectLifecycle, "production")
+	mockICTX.GetConfiguration().Set(flags.FlagProjectTags, "team=backend")
+	mockICTX.GetConfiguration().Set(flags.FlagProjectName, "my-sbom-project")
+
+	osFlowsConfig := mockICTX.GetConfiguration().Clone()
+	osFlowsConfig.Set(flags.FlagSBOM, "testdata/bom.json")
+
+	mockEngine.EXPECT().InvokeWithConfig(sbommonitor.OsFlowsMonitorWorkflowID, osFlowsConfig).
+		DoAndReturn(func(_ workflow.Identifier, cfg configuration.Configuration) ([]workflow.Data, error) {
+			assert.Equal(t, "critical", cfg.GetString(flags.FlagProjectBusinessCriticality))
+			assert.Equal(t, "production", cfg.GetString(flags.FlagProjectEnvironment))
+			assert.Equal(t, "production", cfg.GetString(flags.FlagProjectLifecycle))
+			assert.Equal(t, "team=backend", cfg.GetString(flags.FlagProjectTags))
+			assert.Equal(t, "my-sbom-project", cfg.GetString(flags.FlagProjectName))
+			return []workflow.Data{}, nil
+		}).Times(1)
+
+	result, err := sbommonitor.MonitorWorkflow(mockICTX, []workflow.Data{})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestSBOMMonitorWorkflow_DflyRollout_NoFileFlag(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockEngine := mocks.NewMockEngine(ctrl)
+
+	mockICTX := mockInvocationContext(t, ctrl, "", mockEngine)
+	mockICTX.GetConfiguration().Set(flags.FlagExperimental, true)
+	mockICTX.GetConfiguration().Set(sbommonitor.FeatureFlagSBOMMonitor, true)
+	mockICTX.GetConfiguration().Set(sbommonitor.FeatureFlagDflySbomMonitor, true)
+
+	_, err := sbommonitor.MonitorWorkflow(mockICTX, []workflow.Data{})
+
+	assert.ErrorContains(t, err, "Flag `--file` is required to execute this command.")
+}
+
 func TestSBOMMonitorWorkflow_NoRemoteRepoURL(t *testing.T) {
 	mockICTX := createMockICTX(t)
 	mockICTX.GetConfiguration().Set("experimental", true)

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -38,14 +38,20 @@ const (
 	FlagTargetReference              = "target-reference"
 	FlagIncludeProvenance            = "include-provenance"
 
-	// OS Flows test flags.
-	FlagReachability       = "reachability"
-	FlagReachabilityFilter = "reachability-filter"
-	FlagSBOM               = "sbom"
-	FlagSourceDir          = "source-dir"
-	FlagRiskScoreThreshold = "risk-score-threshold"
-	FlagSeverityThreshold  = "severity-threshold"
-	FlagGoModuleLevel      = "go-module-level"
+	// OS Flows flags.
+	FlagReachability               = "reachability"
+	FlagReachabilityFilter         = "reachability-filter"
+	FlagSBOM                       = "sbom"
+	FlagSourceDir                  = "source-dir"
+	FlagRiskScoreThreshold         = "risk-score-threshold"
+	FlagSeverityThreshold          = "severity-threshold"
+	FlagGoModuleLevel              = "go-module-level"
+	FlagProjectName                = "project-name"
+	FlagProjectEnvironment         = "project-environment"
+	FlagProjectLifecycle           = "project-lifecycle"
+	FlagProjectBusinessCriticality = "project-business-criticality"
+	FlagProjectTags                = "project-tags"
+	FlagTags                       = "tags"
 )
 
 func GetSBOMCreateFlagSet() *pflag.FlagSet {
@@ -114,6 +120,15 @@ func GetSBOMMonitorFlagSet() *pflag.FlagSet {
 	flagSet.String(FlagPolicyPath, "", "Manually pass a path to a .snyk policy file.")
 	flagSet.String(FlagRemoteRepoURL, "", "Set or override the remote URL for the repository that you would like to monitor.")
 	flagSet.String(FlagTargetReference, "", "Specify a reference that differentiates this project, for example, a branch name or version.")
+
+	// Flags forwarded to the os-flows monitor workflow when dragonfly is enabled.
+	flagSet.String(FlagSBOM, "", "Specify an SBOM file to be monitored.")
+	flagSet.String(FlagProjectName, "", "Specify a name for the project.")
+	flagSet.String(FlagProjectEnvironment, "", "Set the project environment project attribute to one or more values (comma-separated).")
+	flagSet.String(FlagProjectLifecycle, "", "Set the project lifecycle project attribute to one or more values (comma-separated).")
+	flagSet.String(FlagProjectBusinessCriticality, "", "Set the project business criticality project attribute to one or more values (comma-separated).")
+	flagSet.String(FlagProjectTags, "", `Set the project tags to one or more values (comma-separated key value pairs with an "=" separator).`)
+	flagSet.String(FlagTags, "", "This is an alias for --project-tags.")
 
 	return flagSet
 }


### PR DESCRIPTION
# What this does?

Adds a routing for the dragonfly SBOM Monitor flow.

[PR](https://github.com/snyk/cli-extension-os-flows/pull/227) which registers the new flow in `cli-extension-os-flows`.