### PR TITLE
feat: [CMPA-604] Adds support for SBOM include component metadata

### DIFF
--- a/internal/commands/sbomcreate/depgraph.go
+++ b/internal/commands/sbomcreate/depgraph.go
@@ -34,27 +34,8 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 	version := config.GetString(flags.FlagVersion)
 
 	depGraphConfig := config.Clone()
-	if config.GetBool(flags.FlagAllProjects) {
-		depGraphConfig.Set("fail-fast", true)
-	}
-
-	allowIncomplete := config.GetBool(flags.FlagAllowIncompleteSBOM)
-	if allowIncomplete {
-		depGraphConfig.Set("fail-fast", false)
-		depGraphConfig.Set("print-output-jsonl-with-errors", true)
-	}
-
-	// Currently, we don't support dotnet runtime resolution for SBOMs.
-	// This will come in a future release.
-	depGraphConfig.Set("dotnet-runtime-resolution", false)
-
-	useSCAPlugins, err := shouldUseSCAPlugins(config, logger)
-	if err != nil {
+	if err := applyDepGraphConfig(depGraphConfig, logger); err != nil {
 		return nil, err
-	}
-	if useSCAPlugins {
-		depGraphConfig.Set("use-sbom-resolution", true)
-		depGraphConfig.Set("force-single-graph", true)
 	}
 
 	depGraphs, err := engine.InvokeWithConfig(DepGraphWorkflowID, depGraphConfig)
@@ -103,6 +84,38 @@ func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
 		DepGraphBytes: depGraphsBytes,
 		ScanErrors:    scanErrors,
 	}, nil
+}
+
+// applyDepGraphConfig applies the SBOM-specific overrides to the (already cloned)
+// config used when invoking the depgraph workflow.
+func applyDepGraphConfig(depGraphConfig configuration.Configuration, logger *zerolog.Logger) error {
+	if depGraphConfig.GetBool(flags.FlagAllProjects) {
+		depGraphConfig.Set("fail-fast", true)
+	}
+
+	if depGraphConfig.GetBool(flags.FlagAllowIncompleteSBOM) {
+		depGraphConfig.Set("fail-fast", false)
+		depGraphConfig.Set("print-output-jsonl-with-errors", true)
+	}
+
+	// Currently, we don't support dotnet runtime resolution for SBOMs.
+	// This will come in a future release.
+	depGraphConfig.Set("dotnet-runtime-resolution", false)
+
+	if depGraphConfig.GetBool(constants.FeatureFlagSbomIncludeComponentMetadata) {
+		depGraphConfig.Set("include-component-metadata", true)
+	}
+
+	useSCAPlugins, err := shouldUseSCAPlugins(depGraphConfig, logger)
+	if err != nil {
+		return err
+	}
+	if useSCAPlugins {
+		depGraphConfig.Set("use-sbom-resolution", true)
+		depGraphConfig.Set("force-single-graph", true)
+	}
+
+	return nil
 }
 
 func getInputDirectories(config configuration.Configuration) ([]string, error) {

--- a/internal/commands/sbomcreate/sbomcreate.go
+++ b/internal/commands/sbomcreate/sbomcreate.go
@@ -26,8 +26,9 @@ func RegisterWorkflows(e workflow.Engine) error {
 
 	config_utils.AddFeatureFlagToConfig(e, constants.FeatureFlagUvCLI, "enableUvCLI")
 	config_utils.AddFeatureFlagsToConfig(e, map[string]string{
-		constants.FeatureFlagShowMavenBuildScope: constants.ShowMavenBuildScope,
-		constants.FeatureFlagShowNpmScope:        constants.ShowNpmScope,
+		constants.FeatureFlagShowMavenBuildScope:          constants.ShowMavenBuildScope,
+		constants.FeatureFlagShowNpmScope:                 constants.ShowNpmScope,
+		constants.FeatureFlagSbomIncludeComponentMetadata: constants.SbomIncludeComponentMetadata,
 	})
 
 	return nil
@@ -59,6 +60,7 @@ func SBOMWorkflow(
 	ai := ictx.GetAnalytics()
 	ai.AddExtensionBoolValue(constants.ShowMavenBuildScope, config.GetBool(constants.FeatureFlagShowMavenBuildScope))
 	ai.AddExtensionBoolValue(constants.ShowNpmScope, config.GetBool(constants.FeatureFlagShowNpmScope))
+	ai.AddExtensionBoolValue(constants.SbomIncludeComponentMetadata, config.GetBool(constants.FeatureFlagSbomIncludeComponentMetadata))
 	ai.AddExtensionBoolValue(constants.AllowIncompleteSBOM, config.GetBool(flags.FlagAllowIncompleteSBOM))
 
 	depGraphResult, err := GetDepGraph(ictx)

--- a/internal/commands/sbomcreate/sbomcreate_test.go
+++ b/internal/commands/sbomcreate/sbomcreate_test.go
@@ -481,6 +481,46 @@ func TestGetDepGraph_disablesDotnetRuntimeResolutionWhenNotPreviouslySet(t *test
 	assert.NotNil(t, result)
 }
 
+func TestGetDepGraph_includeComponentMetadata(t *testing.T) {
+	tests := []struct {
+		name                           string
+		enableFeatureFlag              bool
+		expectIncludeComponentMetadata bool
+	}{
+		{name: "feature flag enabled sets include-component-metadata", enableFeatureFlag: true, expectIncludeComponentMetadata: true},
+		{name: "feature flag disabled leaves include-component-metadata unset", enableFeatureFlag: false, expectIncludeComponentMetadata: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockEngine := mocks.NewMockEngine(ctrl)
+			mockEngine.EXPECT().
+				InvokeWithConfig(gomock.Eq(sbomcreate.DepGraphWorkflowID), gomock.Any()).
+				DoAndReturn(func(_ workflow.Identifier, cfg configuration.Configuration) ([]workflow.Data, error) {
+					assert.Equal(t, tt.expectIncludeComponentMetadata, cfg.GetBool("include-component-metadata"), "include-component-metadata flag mismatch")
+					return []workflow.Data{newDepGraphData(t, depGraphData)}, nil
+				}).
+				Times(1)
+
+			mockLogger := zerolog.New(io.Discard)
+			mockConfig := configuration.New()
+			mockConfig.Set(constants.FeatureFlagSbomIncludeComponentMetadata, tt.enableFeatureFlag)
+
+			mockICTX := mocks.NewMockInvocationContext(ctrl)
+			mockICTX.EXPECT().GetEngine().Return(mockEngine).AnyTimes()
+			mockICTX.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
+			mockICTX.EXPECT().GetEnhancedLogger().Return(&mockLogger).AnyTimes()
+
+			result, err := sbomcreate.GetDepGraph(mockICTX)
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+		})
+	}
+}
+
 func TestGetDepGraph_uvSupport(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -20,3 +20,9 @@ const ShowNpmScope = "show-npm-scope"
 
 // AllowIncompleteSBOM is the analytics key for the allow-incomplete-sbom CLI flag.
 const AllowIncompleteSBOM = "allow-incomplete-sbom"
+
+// FeatureFlagSbomIncludeComponentMetadata gates including component metadata (e.g. package hashes, distribution URLs) in SBOMs.
+const FeatureFlagSbomIncludeComponentMetadata = "internal_snyk_sbom_include_component_metadata_enabled"
+
+// SbomIncludeComponentMetadata is the feature-flag-service name for the include-component-metadata feature.
+const SbomIncludeComponentMetadata = "sbom-include-component-metadata"


### PR DESCRIPTION
### Summary

This adds support for a new flag that is being passed down through the `cli-extension-dep-graph` workflow to the legacy CLI -- `--include-component-metadata`. This flag is sourced from the feature flag gateway, rather than being a command option.

The flag causes the downstream dependency graph output to include hash and distribution url information as labels on the DepGraph, which can then be used to populate `components[].hashes[]` entries and provide a `distribution` entry for `externalUrls` in the CycloneDX format SBOM.

This will initially only be available for the mvn and npm legacy plugins.