### PR TITLE
feat: require --asset-name with --report when FF is enabled

### DIFF
--- a/internal/commands/sbomtest/sbomtest.go
+++ b/internal/commands/sbomtest/sbomtest.go
@@ -67,8 +67,14 @@ func TestWorkflow(
 	// `--report` is the successor to the (removed) `sbom monitor` command;
 	// keep it behind the same rollout FF so that we don't widen access
 	// during the migration.
-	if config.GetBool(flags.FlagReport) && !config.GetBool(FeatureFlagDflySbomMonitor) {
-		return nil, errFactory.NewFeatureNotPermittedError(FeatureFlagDflySbomMonitor)
+	if config.GetBool(flags.FlagReport) {
+		if !config.GetBool(FeatureFlagDflySbomMonitor) {
+			return nil, errFactory.NewFeatureNotPermittedError(FeatureFlagDflySbomMonitor)
+		}
+
+		if config.GetString(flags.FlagAssetName) == "" {
+			return nil, errFactory.NewMissingAssetNameFlagError()
+		}
 	}
 
 	osFlowsTestConfig := config.Clone()

--- a/internal/commands/sbomtest/sbomtest_test.go
+++ b/internal/commands/sbomtest/sbomtest_test.go
@@ -97,6 +97,64 @@ func TestSBOMTestWorkflow_ReportFlag_FFEnabled_DelegatesToOSF(t *testing.T) {
 	mockICTX.GetConfiguration().Set("file", "testdata/bom.json")
 	mockICTX.GetConfiguration().Set(flags.FlagReport, true)
 	mockICTX.GetConfiguration().Set(sbomtest.FeatureFlagDflySbomMonitor, true)
+	mockICTX.GetConfiguration().Set(flags.FlagAssetName, "my-asset")
+
+	osFlowsTestConfig := mockICTX.GetConfiguration().Clone()
+	osFlowsTestConfig.Set(flags.FlagSBOM, "testdata/bom.json")
+
+	mockEngine.EXPECT().InvokeWithConfig(sbomtest.OsFlowsTestWorkflowID, osFlowsTestConfig).Return([]workflow.Data{}, nil).Times(1)
+
+	result, err := sbomtest.TestWorkflow(mockICTX, []workflow.Data{})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestSBOMTestWorkflow_ReportFlag_FFEnabled_NoAssetName_ReturnsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockEngine := mocks.NewMockEngine(ctrl)
+
+	mockICTX := mockInvocationContext(t, ctrl, mockEngine)
+	mockICTX.GetConfiguration().Set("file", "testdata/bom.json")
+	mockICTX.GetConfiguration().Set(flags.FlagReport, true)
+	mockICTX.GetConfiguration().Set(sbomtest.FeatureFlagDflySbomMonitor, true)
+
+	mockEngine.EXPECT().InvokeWithConfig(gomock.Any(), gomock.Any()).Times(0)
+
+	_, err := sbomtest.TestWorkflow(mockICTX, []workflow.Data{})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "Flag `--asset-name` is required when using `--report`.")
+}
+
+func TestSBOMTestWorkflow_ReportFlag_FFEnabled_EmptyAssetName_ReturnsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockEngine := mocks.NewMockEngine(ctrl)
+
+	mockICTX := mockInvocationContext(t, ctrl, mockEngine)
+	mockICTX.GetConfiguration().Set("file", "testdata/bom.json")
+	mockICTX.GetConfiguration().Set(flags.FlagReport, true)
+	mockICTX.GetConfiguration().Set(sbomtest.FeatureFlagDflySbomMonitor, true)
+	mockICTX.GetConfiguration().Set(flags.FlagAssetName, "")
+
+	mockEngine.EXPECT().InvokeWithConfig(gomock.Any(), gomock.Any()).Times(0)
+
+	_, err := sbomtest.TestWorkflow(mockICTX, []workflow.Data{})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "Flag `--asset-name` is required when using `--report`.")
+}
+
+func TestSBOMTestWorkflow_NoReportFlag_NoAssetName_DelegatesToOSF(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockEngine := mocks.NewMockEngine(ctrl)
+
+	mockICTX := mockInvocationContext(t, ctrl, mockEngine)
+	mockICTX.GetConfiguration().Set("file", "testdata/bom.json")
+	mockICTX.GetConfiguration().Set(sbomtest.FeatureFlagDflySbomMonitor, true)
 
 	osFlowsTestConfig := mockICTX.GetConfiguration().Clone()
 	osFlowsTestConfig.Set(flags.FlagSBOM, "testdata/bom.json")

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -149,6 +149,14 @@ func (ef *ErrorFactory) NewMissingFilenameFlagError() *SBOMExtensionError {
 	)
 }
 
+func (ef *ErrorFactory) NewMissingAssetNameFlagError() *SBOMExtensionError {
+	return ef.newErr(
+		fmt.Errorf("asset-name flag not set"),
+		"Flag `--asset-name` is required when using `--report`. "+
+			"Value should be a name that identifies the asset being monitored.",
+	)
+}
+
 func (ef *ErrorFactory) NewMissingRemoteRepoUrlError() *SBOMExtensionError {
 	return ef.newErr(
 		fmt.Errorf("remote repo URL not found"),


### PR DESCRIPTION
OSF-427

Follow-up to #190. When the `internal_snyk_cli_rollout_dfly_sbom_monitor` rollout FF is enabled and the user runs `snyk sbom test --report` without `--asset-name`, the workflow now fails fast with a helpful error before delegating to the os-flows test workflow, so no Test API call is made.

`--asset-name` is required for the os-flows path to persist results as a monitored project, so without this guard the request would only fail later, deeper in the pipeline. The check is scoped to `--report` + FF-enabled to keep behaviour unchanged for the non-`--report` path and for orgs that don't have the FF yet (those still hit the existing "feature not permitted" error first).

Made with [Cursor](https://cursor.com)